### PR TITLE
fix: lowercase org name from f5xc-SalesDemos to f5xc-salesdemos

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -36,6 +36,6 @@ jobs:
         uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.REPO_ADMIN_TOKEN }}
-          repository: f5xc-SalesDemos/docs-builder
+          repository: f5xc-salesdemos/docs-builder
           event-type: rebuild-image
           client-payload: '{"version": "${{ github.event.release.tag_name }}", "source_repo": "${{ github.repository }}"}'

--- a/.github/workflows/enforce-repo-settings.yml
+++ b/.github/workflows/enforce-repo-settings.yml
@@ -18,7 +18,7 @@ concurrency:
 
 jobs:
   enforce:
-    # TODO: Phase 3 — migrate to f5xc-SalesDemos/f5xc-template
+    # TODO: Phase 3 — migrate to f5xc-salesdemos/f5xc-template
     uses: robinmordasiewicz/f5xc-template/.github/workflows/enforce-repo-settings.yml@main
     secrets:
       repo-admin-token: ${{ secrets.REPO_ADMIN_TOKEN }}

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -18,5 +18,5 @@ concurrency:
 
 jobs:
   docs:
-    # TODO: Phase 3 — migrate to f5xc-SalesDemos/f5xc-template
+    # TODO: Phase 3 — migrate to f5xc-salesdemos/f5xc-template
     uses: robinmordasiewicz/f5xc-template/.github/workflows/github-pages-deploy.yml@main

--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Custom footer with social media links (Facebook, X, LinkedIn, Instagram, YouTube
 
 ## Architecture
 
-This repo is checked out at build time by the [f5xc-docs-builder](https://github.com/f5xc-SalesDemos/docs-builder) reusable workflow into a `theme/` directory. The Astro config references these files as `./theme/fonts/...`, `./theme/styles/...`, etc.
+This repo is checked out at build time by the [f5xc-docs-builder](https://github.com/f5xc-salesdemos/docs-builder) reusable workflow into a `theme/` directory. The Astro config references these files as `./theme/fonts/...`, `./theme/styles/...`, etc.
 
 ```
 Content repo push

--- a/docs/09-components.mdx
+++ b/docs/09-components.mdx
@@ -308,7 +308,7 @@ Check the sidebar: this page has a "New" badge with the `tip` variant applied vi
 
 The image below tests the `starlight-image-zoom` plugin. Click to zoom.
 
-![GitHub Avatar](https://github.com/f5xc-SalesDemos.png)
+![GitHub Avatar](https://github.com/f5xc-salesdemos.png)
 
 ## File Tree
 

--- a/package.json
+++ b/package.json
@@ -7,10 +7,10 @@
   "homepage": "https://f5xc-salesdemos.github.io/docs-theme",
   "repository": {
     "type": "git",
-    "url": "https://github.com/f5xc-SalesDemos/docs-theme"
+    "url": "https://github.com/f5xc-salesdemos/docs-theme"
   },
   "bugs": {
-    "url": "https://github.com/f5xc-SalesDemos/docs-theme/issues"
+    "url": "https://github.com/f5xc-salesdemos/docs-theme/issues"
   },
   "exports": {
     ".": "./index.ts",


### PR DESCRIPTION
## Summary

- Lowercase all `f5xc-SalesDemos` references to `f5xc-salesdemos` to match the canonical org name
- Affects `package.json`, `README.md`, 3 workflow files, and `docs/09-components.mdx`

Closes #4

## Test plan

- [ ] `grep -ri "f5xc-SalesDemos"` returns no matches in tracked files
- [ ] CI checks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)