### PR TITLE
fix: use built-in GITHUB_TOKEN for semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,6 @@ jobs:
             attempt=$((attempt + 1))
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary

- Replace `secrets.REPO_ADMIN_TOKEN` with `secrets.GITHUB_TOKEN` in `release.yml`
- The workflow already declares sufficient permissions for semantic-release

Closes #6

## Test plan

- [ ] Merge this PR — the merge itself triggers the Release workflow
- [ ] Verify Release workflow succeeds with the built-in token

🤖 Generated with [Claude Code](https://claude.com/claude-code)