### PR TITLE
fix: add daily schedule trigger for Docker image updates

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -4,6 +4,8 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+  schedule:
+    - cron: '0 7 * * *'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Added daily cron schedule (`0 7 * * *`) to `github-pages-deploy.yml`
- Site rebuilds daily, automatically picking up any docs-builder Docker image changes
- Part of the pull-based rebuild architecture replacing cross-repo dispatch

Closes #10

## Test plan
- [ ] Verify scheduled runs appear in the Actions tab after merge
- [ ] Confirm Pages site rebuilds successfully on schedule
- [ ] Verify manual `workflow_dispatch` still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)