### PR TITLE
fix: use script's own repo remote instead of cwd for org detection

### DIFF
--- a/scripts/fetch-avatar.sh
+++ b/scripts/fetch-avatar.sh
@@ -1,11 +1,14 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-# Determine the GitHub org from git remote or argument
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# Determine the GitHub org from this repo's remote or argument
 if [ $# -ge 1 ]; then
   ORG="$1"
 else
-  REMOTE_URL=$(git remote get-url origin 2>/dev/null || true)
+  REMOTE_URL=$(git -C "$REPO_ROOT" remote get-url origin 2>/dev/null || true)
   ORG=$(echo "$REMOTE_URL" | sed -E 's|.*github\.com[:/]([^/]+)/.*|\1|')
 fi
 
@@ -15,8 +18,6 @@ if [ -z "$ORG" ]; then
   exit 1
 fi
 
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
 DEST="$REPO_ROOT/assets/github-avatar.png"
 
 echo "Fetching avatar for GitHub org: $ORG"


### PR DESCRIPTION
## Summary
- Resolve `REPO_ROOT` from the script's location before querying git remote
- Use `git -C "$REPO_ROOT"` so the script always reads this repo's remote, regardless of where it's invoked from

Closes #20

## Test plan
- [ ] Run `bash scripts/fetch-avatar.sh` from within the repo
- [ ] Run `bash /full/path/to/scripts/fetch-avatar.sh` from `/tmp` — should still detect `f5xc-salesdemos`
- [ ] Verify `file assets/github-avatar.png` shows valid PNG

🤖 Generated with [Claude Code](https://claude.com/claude-code)