### PR TITLE
fix: add assets path trigger to GitHub Pages Deploy workflow

### DIFF
--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -4,6 +4,7 @@ on:
     branches: [main]
     paths:
       - 'docs/**'
+      - 'assets/**'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
## Summary
- Add `assets/**` to the paths filter in the GitHub Pages Deploy workflow so that changes to `assets/github-avatar.png` (and other assets) trigger a Pages rebuild

## Problem
The avatar was updated in PRs #17 and #21, but the live GitHub Pages site still shows the old image because the deploy workflow only triggers on `docs/**` changes.

## Test plan
- [ ] Verify CI checks pass on this PR
- [ ] After merge, confirm the GitHub Pages Deploy workflow runs (or trigger manually with `gh workflow run`)
- [ ] Check https://f5xc-salesdemos.github.io/docs-theme/ shows the updated avatar

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)