### PR TITLE
fix: use PAT in release workflow to enable downstream dispatch

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,6 @@ jobs:
             attempt=$((attempt + 1))
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Switch `GITHUB_TOKEN` to `REPO_ADMIN_TOKEN` in the semantic-release step of `release.yml`
- `GITHUB_TOKEN`-triggered events cannot start other workflows (GitHub anti-recursion policy), so `dispatch-downstream.yml` never fires
- Using the existing `REPO_ADMIN_TOKEN` PAT allows the release event to propagate

## Test plan
- [ ] Merge this PR and make a releasable commit (e.g., `fix:` prefix)
- [ ] Confirm semantic-release creates a GitHub Release
- [ ] Confirm `Dispatch Downstream Rebuild` workflow runs for the first time
- [ ] Confirm docs-builder receives the `rebuild-image` dispatch

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)