### PR TITLE
fix: rename REPO_ADMIN_TOKEN to RELEASE_TOKEN in workflows

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -35,7 +35,7 @@ jobs:
       - name: Dispatch rebuild-image event
         uses: peter-evans/repository-dispatch@v4
         with:
-          token: ${{ secrets.REPO_ADMIN_TOKEN }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           repository: f5xc-salesdemos/docs-builder
           event-type: rebuild-image
           client-payload: '{"version": "${{ github.event.release.tag_name }}", "source_repo": "${{ github.repository }}"}'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,6 @@ jobs:
             attempt=$((attempt + 1))
           done
         env:
-          GITHUB_TOKEN: ${{ secrets.REPO_ADMIN_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.RELEASE_TOKEN }}
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Rename `REPO_ADMIN_TOKEN` to `RELEASE_TOKEN` in both `release.yml` and `dispatch-downstream.yml`
- Enables using a dedicated fine-grained PAT with only the required permissions
- The `RELEASE_TOKEN` secret needs to be created with:
  - `contents: write` on `f5xc-salesdemos/docs-theme` (for creating GitHub Releases)
  - `contents: read` + `actions: write` on `f5xc-salesdemos/docs-builder` (for repository dispatch)

## Test plan
- [ ] Create `RELEASE_TOKEN` secret in the docs-theme repo settings
- [ ] Merge and verify semantic-release still creates GitHub Releases
- [ ] Verify `Dispatch Downstream Rebuild` workflow triggers successfully

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)