### PR TITLE
fix: remove stale robinmordasiewicz references from dependabot and CONTRIBUTING

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,8 +11,6 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
-    assignees:
-      - "robinmordasiewicz"
     open-pull-requests-limit: 10
     groups:
       actions-minor-patch:
@@ -30,8 +28,6 @@ updates:
       prefix: "chore(deps):"
     labels:
       - "dependencies"
-    assignees:
-      - "robinmordasiewicz"
     open-pull-requests-limit: 10
     groups:
       npm-minor-patch:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -82,4 +82,4 @@ If you are Claude Code, Copilot, or another AI coding assistant, follow these ru
 5. **Never force push** or attempt to bypass branch protection.
 6. **Fill out the PR template checklist** completely.
 7. **Follow the branch naming convention**: `feature/<issue>-desc`, `fix/<issue>-desc`, `docs/<issue>-desc`.
-8. **Respect CODEOWNERS** — `@robinmordasiewicz` is the default reviewer.
+8. **Respect CODEOWNERS** — See the CODEOWNERS file for defaults.


### PR DESCRIPTION
Closes #60

Remove outdated personal references and update configuration to use CODEOWNERS file for centralized reviewer assignment.