### PR TITLE
docs: add HashiCorp Flight Icons visual reference page

### DIFF
--- a/docs/hashicorp-icons.mdx
+++ b/docs/hashicorp-icons.mdx
@@ -1,0 +1,4133 @@
+---
+title: HashiCorp Flight Icons
+description: Visual reference for all 671 HashiCorp Flight icons from @hashicorp/flight-icons.
+sidebar:
+  order: 14
+---
+
+Complete visual reference for every icon in the [`@hashicorp/flight-icons`](https://github.com/hashicorp/design-system/tree/main/packages/flight-icons) package. Icons are loaded from the jsDelivr CDN at 24px and organized by category.
+
+:::note
+These icons are not installed in the docs-builder container. They are rendered here via CDN `<img>` tags for reference. To request native Astro component integration, see [docs-builder issue #80](https://github.com/f5xc-salesdemos/docs-builder/issues/80). For Starlight built-in icons and other icon packs, see the [Icons](/icons/) reference.
+:::
+
+## Services (172)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alibaba-24.svg" alt="alibaba" />
+    </div>
+    <div class="icon-card-label">alibaba</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alibaba-color-24.svg" alt="alibaba-color" />
+    </div>
+    <div class="icon-card-label">alibaba-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/amazon-ecs-24.svg" alt="amazon-ecs" />
+    </div>
+    <div class="icon-card-label">amazon-ecs</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/amazon-ecs-color-24.svg" alt="amazon-ecs-color" />
+    </div>
+    <div class="icon-card-label">amazon-ecs-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/amazon-eks-24.svg" alt="amazon-eks" />
+    </div>
+    <div class="icon-card-label">amazon-eks</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/amazon-eks-color-24.svg" alt="amazon-eks-color" />
+    </div>
+    <div class="icon-card-label">amazon-eks-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ansible-automation-platform-24.svg" alt="ansible-automation-platform" />
+    </div>
+    <div class="icon-card-label">ansible-automation-platform</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ansible-automation-platform-color-24.svg" alt="ansible-automation-platform-color" />
+    </div>
+    <div class="icon-card-label">ansible-automation-platform-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ansible-community-24.svg" alt="ansible-community" />
+    </div>
+    <div class="icon-card-label">ansible-community</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ansible-community-color-24.svg" alt="ansible-community-color" />
+    </div>
+    <div class="icon-card-label">ansible-community-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/apple-24.svg" alt="apple" />
+    </div>
+    <div class="icon-card-label">apple</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/apple-color-24.svg" alt="apple-color" />
+    </div>
+    <div class="icon-card-label">apple-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/auth0-24.svg" alt="auth0" />
+    </div>
+    <div class="icon-card-label">auth0</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/auth0-color-24.svg" alt="auth0-color" />
+    </div>
+    <div class="icon-card-label">auth0-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-24.svg" alt="aws" />
+    </div>
+    <div class="icon-card-label">aws</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-cdk-24.svg" alt="aws-cdk" />
+    </div>
+    <div class="icon-card-label">aws-cdk</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-cdk-color-24.svg" alt="aws-cdk-color" />
+    </div>
+    <div class="icon-card-label">aws-cdk-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-cloudwatch-24.svg" alt="aws-cloudwatch" />
+    </div>
+    <div class="icon-card-label">aws-cloudwatch</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-cloudwatch-color-24.svg" alt="aws-cloudwatch-color" />
+    </div>
+    <div class="icon-card-label">aws-cloudwatch-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-color-24.svg" alt="aws-color" />
+    </div>
+    <div class="icon-card-label">aws-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-ec2-24.svg" alt="aws-ec2" />
+    </div>
+    <div class="icon-card-label">aws-ec2</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-ec2-color-24.svg" alt="aws-ec2-color" />
+    </div>
+    <div class="icon-card-label">aws-ec2-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-lambda-24.svg" alt="aws-lambda" />
+    </div>
+    <div class="icon-card-label">aws-lambda</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-lambda-color-24.svg" alt="aws-lambda-color" />
+    </div>
+    <div class="icon-card-label">aws-lambda-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-s3-24.svg" alt="aws-s3" />
+    </div>
+    <div class="icon-card-label">aws-s3</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/aws-s3-color-24.svg" alt="aws-s3-color" />
+    </div>
+    <div class="icon-card-label">aws-s3-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-24.svg" alt="azure" />
+    </div>
+    <div class="icon-card-label">azure</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-aks-24.svg" alt="azure-aks" />
+    </div>
+    <div class="icon-card-label">azure-aks</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-aks-color-24.svg" alt="azure-aks-color" />
+    </div>
+    <div class="icon-card-label">azure-aks-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-blob-storage-24.svg" alt="azure-blob-storage" />
+    </div>
+    <div class="icon-card-label">azure-blob-storage</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-blob-storage-color-24.svg" alt="azure-blob-storage-color" />
+    </div>
+    <div class="icon-card-label">azure-blob-storage-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-color-24.svg" alt="azure-color" />
+    </div>
+    <div class="icon-card-label">azure-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-devops-24.svg" alt="azure-devops" />
+    </div>
+    <div class="icon-card-label">azure-devops</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-devops-color-24.svg" alt="azure-devops-color" />
+    </div>
+    <div class="icon-card-label">azure-devops-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-vms-24.svg" alt="azure-vms" />
+    </div>
+    <div class="icon-card-label">azure-vms</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/azure-vms-color-24.svg" alt="azure-vms-color" />
+    </div>
+    <div class="icon-card-label">azure-vms-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bitbucket-24.svg" alt="bitbucket" />
+    </div>
+    <div class="icon-card-label">bitbucket</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bitbucket-color-24.svg" alt="bitbucket-color" />
+    </div>
+    <div class="icon-card-label">bitbucket-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bridgecrew-24.svg" alt="bridgecrew" />
+    </div>
+    <div class="icon-card-label">bridgecrew</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bridgecrew-color-24.svg" alt="bridgecrew-color" />
+    </div>
+    <div class="icon-card-label">bridgecrew-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cisco-24.svg" alt="cisco" />
+    </div>
+    <div class="icon-card-label">cisco</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cisco-color-24.svg" alt="cisco-color" />
+    </div>
+    <div class="icon-card-label">cisco-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloudability-24.svg" alt="cloudability" />
+    </div>
+    <div class="icon-card-label">cloudability</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloudability-color-24.svg" alt="cloudability-color" />
+    </div>
+    <div class="icon-card-label">cloudability-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/codepen-24.svg" alt="codepen" />
+    </div>
+    <div class="icon-card-label">codepen</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/codepen-color-24.svg" alt="codepen-color" />
+    </div>
+    <div class="icon-card-label">codepen-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/confluence-24.svg" alt="confluence" />
+    </div>
+    <div class="icon-card-label">confluence</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/confluence-color-24.svg" alt="confluence-color" />
+    </div>
+    <div class="icon-card-label">confluence-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/confluent-24.svg" alt="confluent" />
+    </div>
+    <div class="icon-card-label">confluent</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/confluent-color-24.svg" alt="confluent-color" />
+    </div>
+    <div class="icon-card-label">confluent-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/datadog-24.svg" alt="datadog" />
+    </div>
+    <div class="icon-card-label">datadog</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/datadog-color-24.svg" alt="datadog-color" />
+    </div>
+    <div class="icon-card-label">datadog-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/digital-ocean-24.svg" alt="digital-ocean" />
+    </div>
+    <div class="icon-card-label">digital-ocean</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/digital-ocean-color-24.svg" alt="digital-ocean-color" />
+    </div>
+    <div class="icon-card-label">digital-ocean-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/docker-24.svg" alt="docker" />
+    </div>
+    <div class="icon-card-label">docker</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/docker-color-24.svg" alt="docker-color" />
+    </div>
+    <div class="icon-card-label">docker-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/duo-24.svg" alt="duo" />
+    </div>
+    <div class="icon-card-label">duo</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/duo-color-24.svg" alt="duo-color" />
+    </div>
+    <div class="icon-card-label">duo-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/elastic-observability-24.svg" alt="elastic-observability" />
+    </div>
+    <div class="icon-card-label">elastic-observability</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/elastic-observability-color-24.svg" alt="elastic-observability-color" />
+    </div>
+    <div class="icon-card-label">elastic-observability-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/f5-24.svg" alt="f5" />
+    </div>
+    <div class="icon-card-label">f5</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/f5-color-24.svg" alt="f5-color" />
+    </div>
+    <div class="icon-card-label">f5-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/facebook-24.svg" alt="facebook" />
+    </div>
+    <div class="icon-card-label">facebook</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/facebook-color-24.svg" alt="facebook-color" />
+    </div>
+    <div class="icon-card-label">facebook-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/figma-24.svg" alt="figma" />
+    </div>
+    <div class="icon-card-label">figma</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/figma-color-24.svg" alt="figma-color" />
+    </div>
+    <div class="icon-card-label">figma-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gcp-24.svg" alt="gcp" />
+    </div>
+    <div class="icon-card-label">gcp</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gcp-color-24.svg" alt="gcp-color" />
+    </div>
+    <div class="icon-card-label">gcp-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-24.svg" alt="git" />
+    </div>
+    <div class="icon-card-label">git</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-color-24.svg" alt="git-color" />
+    </div>
+    <div class="icon-card-label">git-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/github-24.svg" alt="github" />
+    </div>
+    <div class="icon-card-label">github</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/github-color-24.svg" alt="github-color" />
+    </div>
+    <div class="icon-card-label">github-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gitlab-24.svg" alt="gitlab" />
+    </div>
+    <div class="icon-card-label">gitlab</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gitlab-color-24.svg" alt="gitlab-color" />
+    </div>
+    <div class="icon-card-label">gitlab-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-24.svg" alt="google" />
+    </div>
+    <div class="icon-card-label">google</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-color-24.svg" alt="google-color" />
+    </div>
+    <div class="icon-card-label">google-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-docs-24.svg" alt="google-docs" />
+    </div>
+    <div class="icon-card-label">google-docs</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-docs-color-24.svg" alt="google-docs-color" />
+    </div>
+    <div class="icon-card-label">google-docs-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-drive-24.svg" alt="google-drive" />
+    </div>
+    <div class="icon-card-label">google-drive</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-drive-color-24.svg" alt="google-drive-color" />
+    </div>
+    <div class="icon-card-label">google-drive-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-forms-24.svg" alt="google-forms" />
+    </div>
+    <div class="icon-card-label">google-forms</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-forms-color-24.svg" alt="google-forms-color" />
+    </div>
+    <div class="icon-card-label">google-forms-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-sheets-24.svg" alt="google-sheets" />
+    </div>
+    <div class="icon-card-label">google-sheets</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-sheets-color-24.svg" alt="google-sheets-color" />
+    </div>
+    <div class="icon-card-label">google-sheets-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-slides-24.svg" alt="google-slides" />
+    </div>
+    <div class="icon-card-label">google-slides</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/google-slides-color-24.svg" alt="google-slides-color" />
+    </div>
+    <div class="icon-card-label">google-slides-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/grafana-24.svg" alt="grafana" />
+    </div>
+    <div class="icon-card-label">grafana</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/grafana-color-24.svg" alt="grafana-color" />
+    </div>
+    <div class="icon-card-label">grafana-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/helm-24.svg" alt="helm" />
+    </div>
+    <div class="icon-card-label">helm</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/helm-color-24.svg" alt="helm-color" />
+    </div>
+    <div class="icon-card-label">helm-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/infracost-24.svg" alt="infracost" />
+    </div>
+    <div class="icon-card-label">infracost</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/infracost-color-24.svg" alt="infracost-color" />
+    </div>
+    <div class="icon-card-label">infracost-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jenkins-24.svg" alt="jenkins" />
+    </div>
+    <div class="icon-card-label">jenkins</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jenkins-color-24.svg" alt="jenkins-color" />
+    </div>
+    <div class="icon-card-label">jenkins-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jfrog-24.svg" alt="jfrog" />
+    </div>
+    <div class="icon-card-label">jfrog</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jfrog-color-24.svg" alt="jfrog-color" />
+    </div>
+    <div class="icon-card-label">jfrog-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jira-24.svg" alt="jira" />
+    </div>
+    <div class="icon-card-label">jira</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jira-color-24.svg" alt="jira-color" />
+    </div>
+    <div class="icon-card-label">jira-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jwt-24.svg" alt="jwt" />
+    </div>
+    <div class="icon-card-label">jwt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jwt-color-24.svg" alt="jwt-color" />
+    </div>
+    <div class="icon-card-label">jwt-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/kubernetes-24.svg" alt="kubernetes" />
+    </div>
+    <div class="icon-card-label">kubernetes</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/kubernetes-color-24.svg" alt="kubernetes-color" />
+    </div>
+    <div class="icon-card-label">kubernetes-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/lightlytics-24.svg" alt="lightlytics" />
+    </div>
+    <div class="icon-card-label">lightlytics</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/lightlytics-color-24.svg" alt="lightlytics-color" />
+    </div>
+    <div class="icon-card-label">lightlytics-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linkedin-24.svg" alt="linkedin" />
+    </div>
+    <div class="icon-card-label">linkedin</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linkedin-color-24.svg" alt="linkedin-color" />
+    </div>
+    <div class="icon-card-label">linkedin-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linode-24.svg" alt="linode" />
+    </div>
+    <div class="icon-card-label">linode</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linode-color-24.svg" alt="linode-color" />
+    </div>
+    <div class="icon-card-label">linode-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linux-24.svg" alt="linux" />
+    </div>
+    <div class="icon-card-label">linux</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/linux-color-24.svg" alt="linux-color" />
+    </div>
+    <div class="icon-card-label">linux-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/loom-24.svg" alt="loom" />
+    </div>
+    <div class="icon-card-label">loom</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/loom-color-24.svg" alt="loom-color" />
+    </div>
+    <div class="icon-card-label">loom-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/meetup-24.svg" alt="meetup" />
+    </div>
+    <div class="icon-card-label">meetup</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/meetup-color-24.svg" alt="meetup-color" />
+    </div>
+    <div class="icon-card-label">meetup-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/microsoft-24.svg" alt="microsoft" />
+    </div>
+    <div class="icon-card-label">microsoft</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/microsoft-color-24.svg" alt="microsoft-color" />
+    </div>
+    <div class="icon-card-label">microsoft-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/microsoft-teams-24.svg" alt="microsoft-teams" />
+    </div>
+    <div class="icon-card-label">microsoft-teams</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/microsoft-teams-color-24.svg" alt="microsoft-teams-color" />
+    </div>
+    <div class="icon-card-label">microsoft-teams-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minio-24.svg" alt="minio" />
+    </div>
+    <div class="icon-card-label">minio</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minio-color-24.svg" alt="minio-color" />
+    </div>
+    <div class="icon-card-label">minio-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mongodb-24.svg" alt="mongodb" />
+    </div>
+    <div class="icon-card-label">mongodb</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mongodb-color-24.svg" alt="mongodb-color" />
+    </div>
+    <div class="icon-card-label">mongodb-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/new-relic-24.svg" alt="new-relic" />
+    </div>
+    <div class="icon-card-label">new-relic</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/new-relic-color-24.svg" alt="new-relic-color" />
+    </div>
+    <div class="icon-card-label">new-relic-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/okta-24.svg" alt="okta" />
+    </div>
+    <div class="icon-card-label">okta</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/okta-color-24.svg" alt="okta-color" />
+    </div>
+    <div class="icon-card-label">okta-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/opa-24.svg" alt="opa" />
+    </div>
+    <div class="icon-card-label">opa</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/opa-color-24.svg" alt="opa-color" />
+    </div>
+    <div class="icon-card-label">opa-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/openid-24.svg" alt="openid" />
+    </div>
+    <div class="icon-card-label">openid</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/openid-color-24.svg" alt="openid-color" />
+    </div>
+    <div class="icon-card-label">openid-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/openstack-24.svg" alt="openstack" />
+    </div>
+    <div class="icon-card-label">openstack</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/openstack-color-24.svg" alt="openstack-color" />
+    </div>
+    <div class="icon-card-label">openstack-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/oracle-24.svg" alt="oracle" />
+    </div>
+    <div class="icon-card-label">oracle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/oracle-color-24.svg" alt="oracle-color" />
+    </div>
+    <div class="icon-card-label">oracle-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pack-24.svg" alt="pack" />
+    </div>
+    <div class="icon-card-label">pack</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pack-color-24.svg" alt="pack-color" />
+    </div>
+    <div class="icon-card-label">pack-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pager-duty-24.svg" alt="pager-duty" />
+    </div>
+    <div class="icon-card-label">pager-duty</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pager-duty-color-24.svg" alt="pager-duty-color" />
+    </div>
+    <div class="icon-card-label">pager-duty-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ping-identity -24.svg" alt="ping-identity " />
+    </div>
+    <div class="icon-card-label">ping-identity </div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ping-identity-color-24.svg" alt="ping-identity-color" />
+    </div>
+    <div class="icon-card-label">ping-identity-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/postgres-24.svg" alt="postgres" />
+    </div>
+    <div class="icon-card-label">postgres</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/postgres-color-24.svg" alt="postgres-color" />
+    </div>
+    <div class="icon-card-label">postgres-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rabbitmq-24.svg" alt="rabbitmq" />
+    </div>
+    <div class="icon-card-label">rabbitmq</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rabbitmq-color-24.svg" alt="rabbitmq-color" />
+    </div>
+    <div class="icon-card-label">rabbitmq-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/saml-24.svg" alt="saml" />
+    </div>
+    <div class="icon-card-label">saml</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/saml-color-24.svg" alt="saml-color" />
+    </div>
+    <div class="icon-card-label">saml-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/service-now-24.svg" alt="service-now" />
+    </div>
+    <div class="icon-card-label">service-now</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/service-now-color-24.svg" alt="service-now-color" />
+    </div>
+    <div class="icon-card-label">service-now-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/slack-24.svg" alt="slack" />
+    </div>
+    <div class="icon-card-label">slack</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/slack-color-24.svg" alt="slack-color" />
+    </div>
+    <div class="icon-card-label">slack-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/snyk-24.svg" alt="snyk" />
+    </div>
+    <div class="icon-card-label">snyk</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/snyk-color-24.svg" alt="snyk-color" />
+    </div>
+    <div class="icon-card-label">snyk-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/splunk-24.svg" alt="splunk" />
+    </div>
+    <div class="icon-card-label">splunk</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/splunk-color-24.svg" alt="splunk-color" />
+    </div>
+    <div class="icon-card-label">splunk-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twilio-24.svg" alt="twilio" />
+    </div>
+    <div class="icon-card-label">twilio</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twilio-color-24.svg" alt="twilio-color" />
+    </div>
+    <div class="icon-card-label">twilio-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitch-24.svg" alt="twitch" />
+    </div>
+    <div class="icon-card-label">twitch</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitch-color-24.svg" alt="twitch-color" />
+    </div>
+    <div class="icon-card-label">twitch-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitter-24.svg" alt="twitter" />
+    </div>
+    <div class="icon-card-label">twitter</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitter-color-24.svg" alt="twitter-color" />
+    </div>
+    <div class="icon-card-label">twitter-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitter-x-24.svg" alt="twitter-x" />
+    </div>
+    <div class="icon-card-label">twitter-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/twitter-x-color-24.svg" alt="twitter-x-color" />
+    </div>
+    <div class="icon-card-label">twitter-x-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vantage-24.svg" alt="vantage" />
+    </div>
+    <div class="icon-card-label">vantage</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vantage-color-24.svg" alt="vantage-color" />
+    </div>
+    <div class="icon-card-label">vantage-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/venafi-24.svg" alt="venafi" />
+    </div>
+    <div class="icon-card-label">venafi</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/venafi-color-24.svg" alt="venafi-color" />
+    </div>
+    <div class="icon-card-label">venafi-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vercel-24.svg" alt="vercel" />
+    </div>
+    <div class="icon-card-label">vercel</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vercel-color-24.svg" alt="vercel-color" />
+    </div>
+    <div class="icon-card-label">vercel-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vmware-24.svg" alt="vmware" />
+    </div>
+    <div class="icon-card-label">vmware</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vmware-color-24.svg" alt="vmware-color" />
+    </div>
+    <div class="icon-card-label">vmware-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/youtube-24.svg" alt="youtube" />
+    </div>
+    <div class="icon-card-label">youtube</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/youtube-color-24.svg" alt="youtube-color" />
+    </div>
+    <div class="icon-card-label">youtube-color</div>
+  </div>
+</div>
+
+## Interface (82)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/align-center-24.svg" alt="align-center" />
+    </div>
+    <div class="icon-card-label">align-center</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/align-justify-24.svg" alt="align-justify" />
+    </div>
+    <div class="icon-card-label">align-justify</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/align-left-24.svg" alt="align-left" />
+    </div>
+    <div class="icon-card-label">align-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/align-right-24.svg" alt="align-right" />
+    </div>
+    <div class="icon-card-label">align-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/battery-24.svg" alt="battery" />
+    </div>
+    <div class="icon-card-label">battery</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/battery-charging-24.svg" alt="battery-charging" />
+    </div>
+    <div class="icon-card-label">battery-charging</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-24.svg" alt="bookmark" />
+    </div>
+    <div class="icon-card-label">bookmark</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-add-24.svg" alt="bookmark-add" />
+    </div>
+    <div class="icon-card-label">bookmark-add</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-add-fill-24.svg" alt="bookmark-add-fill" />
+    </div>
+    <div class="icon-card-label">bookmark-add-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-fill-24.svg" alt="bookmark-fill" />
+    </div>
+    <div class="icon-card-label">bookmark-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-remove-24.svg" alt="bookmark-remove" />
+    </div>
+    <div class="icon-card-label">bookmark-remove</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bookmark-remove-fill-24.svg" alt="bookmark-remove-fill" />
+    </div>
+    <div class="icon-card-label">bookmark-remove-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bottom-24.svg" alt="bottom" />
+    </div>
+    <div class="icon-card-label">bottom</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/command-24.svg" alt="command" />
+    </div>
+    <div class="icon-card-label">command</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/crop-24.svg" alt="crop" />
+    </div>
+    <div class="icon-card-label">crop</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/dashboard-24.svg" alt="dashboard" />
+    </div>
+    <div class="icon-card-label">dashboard</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/delete-24.svg" alt="delete" />
+    </div>
+    <div class="icon-card-label">delete</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/download-24.svg" alt="download" />
+    </div>
+    <div class="icon-card-label">download</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/edit-24.svg" alt="edit" />
+    </div>
+    <div class="icon-card-label">edit</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/end-24.svg" alt="end" />
+    </div>
+    <div class="icon-card-label">end</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/entry-point-24.svg" alt="entry-point" />
+    </div>
+    <div class="icon-card-label">entry-point</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/exit-point-24.svg" alt="exit-point" />
+    </div>
+    <div class="icon-card-label">exit-point</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/external-link-24.svg" alt="external-link" />
+    </div>
+    <div class="icon-card-label">external-link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/filter-24.svg" alt="filter" />
+    </div>
+    <div class="icon-card-label">filter</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/filter-circle-24.svg" alt="filter-circle" />
+    </div>
+    <div class="icon-card-label">filter-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/filter-fill-24.svg" alt="filter-fill" />
+    </div>
+    <div class="icon-card-label">filter-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/grid-24.svg" alt="grid" />
+    </div>
+    <div class="icon-card-label">grid</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/grid-alt-24.svg" alt="grid-alt" />
+    </div>
+    <div class="icon-card-label">grid-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/home-24.svg" alt="home" />
+    </div>
+    <div class="icon-card-label">home</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/jump-link-24.svg" alt="jump-link" />
+    </div>
+    <div class="icon-card-label">jump-link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/layout-24.svg" alt="layout" />
+    </div>
+    <div class="icon-card-label">layout</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/link-24.svg" alt="link" />
+    </div>
+    <div class="icon-card-label">link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/list-24.svg" alt="list" />
+    </div>
+    <div class="icon-card-label">list</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/maximize-24.svg" alt="maximize" />
+    </div>
+    <div class="icon-card-label">maximize</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/maximize-alt-24.svg" alt="maximize-alt" />
+    </div>
+    <div class="icon-card-label">maximize-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/menu-24.svg" alt="menu" />
+    </div>
+    <div class="icon-card-label">menu</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minimize-24.svg" alt="minimize" />
+    </div>
+    <div class="icon-card-label">minimize</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minimize-alt-24.svg" alt="minimize-alt" />
+    </div>
+    <div class="icon-card-label">minimize-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/more-horizontal-24.svg" alt="more-horizontal" />
+    </div>
+    <div class="icon-card-label">more-horizontal</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/more-vertical-24.svg" alt="more-vertical" />
+    </div>
+    <div class="icon-card-label">more-vertical</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mouse-pointer-24.svg" alt="mouse-pointer" />
+    </div>
+    <div class="icon-card-label">mouse-pointer</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/move-horizontal-24.svg" alt="move-horizontal" />
+    </div>
+    <div class="icon-card-label">move-horizontal</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/paperclip-24.svg" alt="paperclip" />
+    </div>
+    <div class="icon-card-label">paperclip</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pen-tool-24.svg" alt="pen-tool" />
+    </div>
+    <div class="icon-card-label">pen-tool</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pencil-tool-24.svg" alt="pencil-tool" />
+    </div>
+    <div class="icon-card-label">pencil-tool</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pin-24.svg" alt="pin" />
+    </div>
+    <div class="icon-card-label">pin</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pin-off-24.svg" alt="pin-off" />
+    </div>
+    <div class="icon-card-label">pin-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/power-24.svg" alt="power" />
+    </div>
+    <div class="icon-card-label">power</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/printer-24.svg" alt="printer" />
+    </div>
+    <div class="icon-card-label">printer</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/reload-24.svg" alt="reload" />
+    </div>
+    <div class="icon-card-label">reload</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/repeat-24.svg" alt="repeat" />
+    </div>
+    <div class="icon-card-label">repeat</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/resize-column-24.svg" alt="resize-column" />
+    </div>
+    <div class="icon-card-label">resize-column</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rotate-ccw-24.svg" alt="rotate-ccw" />
+    </div>
+    <div class="icon-card-label">rotate-ccw</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rotate-cw-24.svg" alt="rotate-cw" />
+    </div>
+    <div class="icon-card-label">rotate-cw</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/search-24.svg" alt="search" />
+    </div>
+    <div class="icon-card-label">search</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/share-24.svg" alt="share" />
+    </div>
+    <div class="icon-card-label">share</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sidebar-24.svg" alt="sidebar" />
+    </div>
+    <div class="icon-card-label">sidebar</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sidebar-hide-24.svg" alt="sidebar-hide" />
+    </div>
+    <div class="icon-card-label">sidebar-hide</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sidebar-show-24.svg" alt="sidebar-show" />
+    </div>
+    <div class="icon-card-label">sidebar-show</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sign-in-24.svg" alt="sign-in" />
+    </div>
+    <div class="icon-card-label">sign-in</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sign-out-24.svg" alt="sign-out" />
+    </div>
+    <div class="icon-card-label">sign-out</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/slash-24.svg" alt="slash" />
+    </div>
+    <div class="icon-card-label">slash</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/slash-square-24.svg" alt="slash-square" />
+    </div>
+    <div class="icon-card-label">slash-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sort-asc-24.svg" alt="sort-asc" />
+    </div>
+    <div class="icon-card-label">sort-asc</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sort-desc-24.svg" alt="sort-desc" />
+    </div>
+    <div class="icon-card-label">sort-desc</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/start-24.svg" alt="start" />
+    </div>
+    <div class="icon-card-label">start</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/switcher-24.svg" alt="switcher" />
+    </div>
+    <div class="icon-card-label">switcher</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sync-24.svg" alt="sync" />
+    </div>
+    <div class="icon-card-label">sync</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sync-alert-24.svg" alt="sync-alert" />
+    </div>
+    <div class="icon-card-label">sync-alert</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sync-reverse-24.svg" alt="sync-reverse" />
+    </div>
+    <div class="icon-card-label">sync-reverse</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/tag-24.svg" alt="tag" />
+    </div>
+    <div class="icon-card-label">tag</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/text-wrap-24.svg" alt="text-wrap" />
+    </div>
+    <div class="icon-card-label">text-wrap</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/toggle-left-24.svg" alt="toggle-left" />
+    </div>
+    <div class="icon-card-label">toggle-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/toggle-right-24.svg" alt="toggle-right" />
+    </div>
+    <div class="icon-card-label">toggle-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/top-24.svg" alt="top" />
+    </div>
+    <div class="icon-card-label">top</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/trash-24.svg" alt="trash" />
+    </div>
+    <div class="icon-card-label">trash</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/type-24.svg" alt="type" />
+    </div>
+    <div class="icon-card-label">type</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/unfold-close-24.svg" alt="unfold-close" />
+    </div>
+    <div class="icon-card-label">unfold-close</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/unfold-open-24.svg" alt="unfold-open" />
+    </div>
+    <div class="icon-card-label">unfold-open</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/upload-24.svg" alt="upload" />
+    </div>
+    <div class="icon-card-label">upload</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/zoom-in-24.svg" alt="zoom-in" />
+    </div>
+    <div class="icon-card-label">zoom-in</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/zoom-out-24.svg" alt="zoom-out" />
+    </div>
+    <div class="icon-card-label">zoom-out</div>
+  </div>
+</div>
+
+## Products (72)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-24.svg" alt="boundary" />
+    </div>
+    <div class="icon-card-label">boundary</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-color-24.svg" alt="boundary-color" />
+    </div>
+    <div class="icon-card-label">boundary-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-fill-24.svg" alt="boundary-fill" />
+    </div>
+    <div class="icon-card-label">boundary-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-fill-color-24.svg" alt="boundary-fill-color" />
+    </div>
+    <div class="icon-card-label">boundary-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-square-24.svg" alt="boundary-square" />
+    </div>
+    <div class="icon-card-label">boundary-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/boundary-square-color-24.svg" alt="boundary-square-color" />
+    </div>
+    <div class="icon-card-label">boundary-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-24.svg" alt="consul" />
+    </div>
+    <div class="icon-card-label">consul</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-color-24.svg" alt="consul-color" />
+    </div>
+    <div class="icon-card-label">consul-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-fill-24.svg" alt="consul-fill" />
+    </div>
+    <div class="icon-card-label">consul-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-fill-color-24.svg" alt="consul-fill-color" />
+    </div>
+    <div class="icon-card-label">consul-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-square-24.svg" alt="consul-square" />
+    </div>
+    <div class="icon-card-label">consul-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/consul-square-color-24.svg" alt="consul-square-color" />
+    </div>
+    <div class="icon-card-label">consul-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-24.svg" alt="hashicorp" />
+    </div>
+    <div class="icon-card-label">hashicorp</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-color-24.svg" alt="hashicorp-color" />
+    </div>
+    <div class="icon-card-label">hashicorp-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-fill-24.svg" alt="hashicorp-fill" />
+    </div>
+    <div class="icon-card-label">hashicorp-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-fill-color-24.svg" alt="hashicorp-fill-color" />
+    </div>
+    <div class="icon-card-label">hashicorp-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-square-24.svg" alt="hashicorp-square" />
+    </div>
+    <div class="icon-card-label">hashicorp-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hashicorp-square-color-24.svg" alt="hashicorp-square-color" />
+    </div>
+    <div class="icon-card-label">hashicorp-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-24.svg" alt="hcp" />
+    </div>
+    <div class="icon-card-label">hcp</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-color-24.svg" alt="hcp-color" />
+    </div>
+    <div class="icon-card-label">hcp-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-fill-24.svg" alt="hcp-fill" />
+    </div>
+    <div class="icon-card-label">hcp-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-fill-color-24.svg" alt="hcp-fill-color" />
+    </div>
+    <div class="icon-card-label">hcp-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-square-24.svg" alt="hcp-square" />
+    </div>
+    <div class="icon-card-label">hcp-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hcp-square-color-24.svg" alt="hcp-square-color" />
+    </div>
+    <div class="icon-card-label">hcp-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-24.svg" alt="nomad" />
+    </div>
+    <div class="icon-card-label">nomad</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-color-24.svg" alt="nomad-color" />
+    </div>
+    <div class="icon-card-label">nomad-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-fill-24.svg" alt="nomad-fill" />
+    </div>
+    <div class="icon-card-label">nomad-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-fill-color-24.svg" alt="nomad-fill-color" />
+    </div>
+    <div class="icon-card-label">nomad-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-square-24.svg" alt="nomad-square" />
+    </div>
+    <div class="icon-card-label">nomad-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/nomad-square-color-24.svg" alt="nomad-square-color" />
+    </div>
+    <div class="icon-card-label">nomad-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-24.svg" alt="packer" />
+    </div>
+    <div class="icon-card-label">packer</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-color-24.svg" alt="packer-color" />
+    </div>
+    <div class="icon-card-label">packer-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-fill-24.svg" alt="packer-fill" />
+    </div>
+    <div class="icon-card-label">packer-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-fill-color-24.svg" alt="packer-fill-color" />
+    </div>
+    <div class="icon-card-label">packer-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-square-24.svg" alt="packer-square" />
+    </div>
+    <div class="icon-card-label">packer-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/packer-square-color-24.svg" alt="packer-square-color" />
+    </div>
+    <div class="icon-card-label">packer-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-24.svg" alt="terraform" />
+    </div>
+    <div class="icon-card-label">terraform</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-color-24.svg" alt="terraform-color" />
+    </div>
+    <div class="icon-card-label">terraform-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-fill-24.svg" alt="terraform-fill" />
+    </div>
+    <div class="icon-card-label">terraform-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-fill-color-24.svg" alt="terraform-fill-color" />
+    </div>
+    <div class="icon-card-label">terraform-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-square-24.svg" alt="terraform-square" />
+    </div>
+    <div class="icon-card-label">terraform-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terraform-square-color-24.svg" alt="terraform-square-color" />
+    </div>
+    <div class="icon-card-label">terraform-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-24.svg" alt="vagrant" />
+    </div>
+    <div class="icon-card-label">vagrant</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-color-24.svg" alt="vagrant-color" />
+    </div>
+    <div class="icon-card-label">vagrant-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-fill-24.svg" alt="vagrant-fill" />
+    </div>
+    <div class="icon-card-label">vagrant-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-fill-color-24.svg" alt="vagrant-fill-color" />
+    </div>
+    <div class="icon-card-label">vagrant-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-square-24.svg" alt="vagrant-square" />
+    </div>
+    <div class="icon-card-label">vagrant-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vagrant-square-color-24.svg" alt="vagrant-square-color" />
+    </div>
+    <div class="icon-card-label">vagrant-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-24.svg" alt="vault" />
+    </div>
+    <div class="icon-card-label">vault</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-color-24.svg" alt="vault-color" />
+    </div>
+    <div class="icon-card-label">vault-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-fill-24.svg" alt="vault-fill" />
+    </div>
+    <div class="icon-card-label">vault-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-fill-color-24.svg" alt="vault-fill-color" />
+    </div>
+    <div class="icon-card-label">vault-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-24.svg" alt="vault-radar" />
+    </div>
+    <div class="icon-card-label">vault-radar</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-color-24.svg" alt="vault-radar-color" />
+    </div>
+    <div class="icon-card-label">vault-radar-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-fill-24.svg" alt="vault-radar-fill" />
+    </div>
+    <div class="icon-card-label">vault-radar-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-fill-color-24.svg" alt="vault-radar-fill-color" />
+    </div>
+    <div class="icon-card-label">vault-radar-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-square-24.svg" alt="vault-radar-square" />
+    </div>
+    <div class="icon-card-label">vault-radar-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-radar-square-color-24.svg" alt="vault-radar-square-color" />
+    </div>
+    <div class="icon-card-label">vault-radar-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-24.svg" alt="vault-secrets" />
+    </div>
+    <div class="icon-card-label">vault-secrets</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-color-24.svg" alt="vault-secrets-color" />
+    </div>
+    <div class="icon-card-label">vault-secrets-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-fill-24.svg" alt="vault-secrets-fill" />
+    </div>
+    <div class="icon-card-label">vault-secrets-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-fill-color-24.svg" alt="vault-secrets-fill-color" />
+    </div>
+    <div class="icon-card-label">vault-secrets-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-square-24.svg" alt="vault-secrets-square" />
+    </div>
+    <div class="icon-card-label">vault-secrets-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-secrets-square-color-24.svg" alt="vault-secrets-square-color" />
+    </div>
+    <div class="icon-card-label">vault-secrets-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-square-24.svg" alt="vault-square" />
+    </div>
+    <div class="icon-card-label">vault-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/vault-square-color-24.svg" alt="vault-square-color" />
+    </div>
+    <div class="icon-card-label">vault-square-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-24.svg" alt="waypoint" />
+    </div>
+    <div class="icon-card-label">waypoint</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-color-24.svg" alt="waypoint-color" />
+    </div>
+    <div class="icon-card-label">waypoint-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-fill-24.svg" alt="waypoint-fill" />
+    </div>
+    <div class="icon-card-label">waypoint-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-fill-color-24.svg" alt="waypoint-fill-color" />
+    </div>
+    <div class="icon-card-label">waypoint-fill-color</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-square-24.svg" alt="waypoint-square" />
+    </div>
+    <div class="icon-card-label">waypoint-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image no-invert">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/waypoint-square-color-24.svg" alt="waypoint-square-color" />
+    </div>
+    <div class="icon-card-label">waypoint-square-color</div>
+  </div>
+</div>
+
+## Development (59)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/api-24.svg" alt="api" />
+    </div>
+    <div class="icon-card-label">api</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/auto-apply-24.svg" alt="auto-apply" />
+    </div>
+    <div class="icon-card-label">auto-apply</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/build-24.svg" alt="build" />
+    </div>
+    <div class="icon-card-label">build</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/change-24.svg" alt="change" />
+    </div>
+    <div class="icon-card-label">change</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/change-circle-24.svg" alt="change-circle" />
+    </div>
+    <div class="icon-card-label">change-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/change-square-24.svg" alt="change-square" />
+    </div>
+    <div class="icon-card-label">change-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/channel-24.svg" alt="channel" />
+    </div>
+    <div class="icon-card-label">channel</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-24.svg" alt="cloud" />
+    </div>
+    <div class="icon-card-label">cloud</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-check-24.svg" alt="cloud-check" />
+    </div>
+    <div class="icon-card-label">cloud-check</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-download-24.svg" alt="cloud-download" />
+    </div>
+    <div class="icon-card-label">cloud-download</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-lightning-24.svg" alt="cloud-lightning" />
+    </div>
+    <div class="icon-card-label">cloud-lightning</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-lock-24.svg" alt="cloud-lock" />
+    </div>
+    <div class="icon-card-label">cloud-lock</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-off-24.svg" alt="cloud-off" />
+    </div>
+    <div class="icon-card-label">cloud-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-upload-24.svg" alt="cloud-upload" />
+    </div>
+    <div class="icon-card-label">cloud-upload</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cloud-x-24.svg" alt="cloud-x" />
+    </div>
+    <div class="icon-card-label">cloud-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/code-24.svg" alt="code" />
+    </div>
+    <div class="icon-card-label">code</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/connection-24.svg" alt="connection" />
+    </div>
+    <div class="icon-card-label">connection</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/connection-gateway-24.svg" alt="connection-gateway" />
+    </div>
+    <div class="icon-card-label">connection-gateway</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cpu-24.svg" alt="cpu" />
+    </div>
+    <div class="icon-card-label">cpu</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/duplicate-24.svg" alt="duplicate" />
+    </div>
+    <div class="icon-card-label">duplicate</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gateway-24.svg" alt="gateway" />
+    </div>
+    <div class="icon-card-label">gateway</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-branch-24.svg" alt="git-branch" />
+    </div>
+    <div class="icon-card-label">git-branch</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-commit-24.svg" alt="git-commit" />
+    </div>
+    <div class="icon-card-label">git-commit</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-merge-24.svg" alt="git-merge" />
+    </div>
+    <div class="icon-card-label">git-merge</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-pull-request-24.svg" alt="git-pull-request" />
+    </div>
+    <div class="icon-card-label">git-pull-request</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/git-repo-24.svg" alt="git-repo" />
+    </div>
+    <div class="icon-card-label">git-repo</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hammer-24.svg" alt="hammer" />
+    </div>
+    <div class="icon-card-label">hammer</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/key-values-24.svg" alt="key-values" />
+    </div>
+    <div class="icon-card-label">key-values</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mainframe-24.svg" alt="mainframe" />
+    </div>
+    <div class="icon-card-label">mainframe</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mesh-24.svg" alt="mesh" />
+    </div>
+    <div class="icon-card-label">mesh</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/module-24.svg" alt="module" />
+    </div>
+    <div class="icon-card-label">module</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/monitor-24.svg" alt="monitor" />
+    </div>
+    <div class="icon-card-label">monitor</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/network-24.svg" alt="network" />
+    </div>
+    <div class="icon-card-label">network</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/network-alt-24.svg" alt="network-alt" />
+    </div>
+    <div class="icon-card-label">network-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/node-24.svg" alt="node" />
+    </div>
+    <div class="icon-card-label">node</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/path-24.svg" alt="path" />
+    </div>
+    <div class="icon-card-label">path</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pipeline-24.svg" alt="pipeline" />
+    </div>
+    <div class="icon-card-label">pipeline</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/plug-24.svg" alt="plug" />
+    </div>
+    <div class="icon-card-label">plug</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/replication-direct-24.svg" alt="replication-direct" />
+    </div>
+    <div class="icon-card-label">replication-direct</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/replication-perf-24.svg" alt="replication-perf" />
+    </div>
+    <div class="icon-card-label">replication-perf</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/scissors-24.svg" alt="scissors" />
+    </div>
+    <div class="icon-card-label">scissors</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/server-24.svg" alt="server" />
+    </div>
+    <div class="icon-card-label">server</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/server-cluster-24.svg" alt="server-cluster" />
+    </div>
+    <div class="icon-card-label">server-cluster</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/serverless-24.svg" alt="serverless" />
+    </div>
+    <div class="icon-card-label">serverless</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/service-24.svg" alt="service" />
+    </div>
+    <div class="icon-card-label">service</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/settings-24.svg" alt="settings" />
+    </div>
+    <div class="icon-card-label">settings</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sliders-24.svg" alt="sliders" />
+    </div>
+    <div class="icon-card-label">sliders</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/smartphone-24.svg" alt="smartphone" />
+    </div>
+    <div class="icon-card-label">smartphone</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/socket-24.svg" alt="socket" />
+    </div>
+    <div class="icon-card-label">socket</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/step-24.svg" alt="step" />
+    </div>
+    <div class="icon-card-label">step</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/tablet-24.svg" alt="tablet" />
+    </div>
+    <div class="icon-card-label">tablet</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terminal-24.svg" alt="terminal" />
+    </div>
+    <div class="icon-card-label">terminal</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/terminal-screen-24.svg" alt="terminal-screen" />
+    </div>
+    <div class="icon-card-label">terminal-screen</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/test-24.svg" alt="test" />
+    </div>
+    <div class="icon-card-label">test</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/tools-24.svg" alt="tools" />
+    </div>
+    <div class="icon-card-label">tools</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/transform-data-24.svg" alt="transform-data" />
+    </div>
+    <div class="icon-card-label">transform-data</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/tv-24.svg" alt="tv" />
+    </div>
+    <div class="icon-card-label">tv</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/webhook-24.svg" alt="webhook" />
+    </div>
+    <div class="icon-card-label">webhook</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/wrench-24.svg" alt="wrench" />
+    </div>
+    <div class="icon-card-label">wrench</div>
+  </div>
+</div>
+
+## Symbols (38)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/ampersand-24.svg" alt="ampersand" />
+    </div>
+    <div class="icon-card-label">ampersand</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/beaker-24.svg" alt="beaker" />
+    </div>
+    <div class="icon-card-label">beaker</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bucket-24.svg" alt="bucket" />
+    </div>
+    <div class="icon-card-label">bucket</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bulb-24.svg" alt="bulb" />
+    </div>
+    <div class="icon-card-label">bulb</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/circle-24.svg" alt="circle" />
+    </div>
+    <div class="icon-card-label">circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/circle-dot-24.svg" alt="circle-dot" />
+    </div>
+    <div class="icon-card-label">circle-dot</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/circle-fill-24.svg" alt="circle-fill" />
+    </div>
+    <div class="icon-card-label">circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/circle-half-24.svg" alt="circle-half" />
+    </div>
+    <div class="icon-card-label">circle-half</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/diamond-24.svg" alt="diamond" />
+    </div>
+    <div class="icon-card-label">diamond</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/diamond-fill-24.svg" alt="diamond-fill" />
+    </div>
+    <div class="icon-card-label">diamond-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/disc-24.svg" alt="disc" />
+    </div>
+    <div class="icon-card-label">disc</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/dot-24.svg" alt="dot" />
+    </div>
+    <div class="icon-card-label">dot</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/dot-half-24.svg" alt="dot-half" />
+    </div>
+    <div class="icon-card-label">dot-half</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/droplet-24.svg" alt="droplet" />
+    </div>
+    <div class="icon-card-label">droplet</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/flag-24.svg" alt="flag" />
+    </div>
+    <div class="icon-card-label">flag</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/gift-24.svg" alt="gift" />
+    </div>
+    <div class="icon-card-label">gift</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/government-24.svg" alt="government" />
+    </div>
+    <div class="icon-card-label">government</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/handshake-24.svg" alt="handshake" />
+    </div>
+    <div class="icon-card-label">handshake</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hash-24.svg" alt="hash" />
+    </div>
+    <div class="icon-card-label">hash</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hexagon-24.svg" alt="hexagon" />
+    </div>
+    <div class="icon-card-label">hexagon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hexagon-fill-24.svg" alt="hexagon-fill" />
+    </div>
+    <div class="icon-card-label">hexagon-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/labyrinth-24.svg" alt="labyrinth" />
+    </div>
+    <div class="icon-card-label">labyrinth</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/layers-24.svg" alt="layers" />
+    </div>
+    <div class="icon-card-label">layers</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/moon-24.svg" alt="moon" />
+    </div>
+    <div class="icon-card-label">moon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/octagon-24.svg" alt="octagon" />
+    </div>
+    <div class="icon-card-label">octagon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/outline-24.svg" alt="outline" />
+    </div>
+    <div class="icon-card-label">outline</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/random-24.svg" alt="random" />
+    </div>
+    <div class="icon-card-label">random</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rocket-24.svg" alt="rocket" />
+    </div>
+    <div class="icon-card-label">rocket</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sparkle-24.svg" alt="sparkle" />
+    </div>
+    <div class="icon-card-label">sparkle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/square-24.svg" alt="square" />
+    </div>
+    <div class="icon-card-label">square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/square-fill-24.svg" alt="square-fill" />
+    </div>
+    <div class="icon-card-label">square-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/sun-24.svg" alt="sun" />
+    </div>
+    <div class="icon-card-label">sun</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/triangle-24.svg" alt="triangle" />
+    </div>
+    <div class="icon-card-label">triangle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/triangle-fill-24.svg" alt="triangle-fill" />
+    </div>
+    <div class="icon-card-label">triangle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/truck-24.svg" alt="truck" />
+    </div>
+    <div class="icon-card-label">truck</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/wand-24.svg" alt="wand" />
+    </div>
+    <div class="icon-card-label">wand</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/zap-24.svg" alt="zap" />
+    </div>
+    <div class="icon-card-label">zap</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/zap-off-24.svg" alt="zap-off" />
+    </div>
+    <div class="icon-card-label">zap-off</div>
+  </div>
+</div>
+
+## Arrows (35)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-down-24.svg" alt="arrow-down" />
+    </div>
+    <div class="icon-card-label">arrow-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-down-circle-24.svg" alt="arrow-down-circle" />
+    </div>
+    <div class="icon-card-label">arrow-down-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-down-left-24.svg" alt="arrow-down-left" />
+    </div>
+    <div class="icon-card-label">arrow-down-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-down-right-24.svg" alt="arrow-down-right" />
+    </div>
+    <div class="icon-card-label">arrow-down-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-left-24.svg" alt="arrow-left" />
+    </div>
+    <div class="icon-card-label">arrow-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-left-circle-24.svg" alt="arrow-left-circle" />
+    </div>
+    <div class="icon-card-label">arrow-left-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-right-24.svg" alt="arrow-right" />
+    </div>
+    <div class="icon-card-label">arrow-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-right-circle-24.svg" alt="arrow-right-circle" />
+    </div>
+    <div class="icon-card-label">arrow-right-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-up-24.svg" alt="arrow-up" />
+    </div>
+    <div class="icon-card-label">arrow-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-up-circle-24.svg" alt="arrow-up-circle" />
+    </div>
+    <div class="icon-card-label">arrow-up-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-up-left-24.svg" alt="arrow-up-left" />
+    </div>
+    <div class="icon-card-label">arrow-up-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/arrow-up-right-24.svg" alt="arrow-up-right" />
+    </div>
+    <div class="icon-card-label">arrow-up-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/caret-24.svg" alt="caret" />
+    </div>
+    <div class="icon-card-label">caret</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevron-down-24.svg" alt="chevron-down" />
+    </div>
+    <div class="icon-card-label">chevron-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevron-left-24.svg" alt="chevron-left" />
+    </div>
+    <div class="icon-card-label">chevron-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevron-right-24.svg" alt="chevron-right" />
+    </div>
+    <div class="icon-card-label">chevron-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevron-up-24.svg" alt="chevron-up" />
+    </div>
+    <div class="icon-card-label">chevron-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevrons-down-24.svg" alt="chevrons-down" />
+    </div>
+    <div class="icon-card-label">chevrons-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevrons-left-24.svg" alt="chevrons-left" />
+    </div>
+    <div class="icon-card-label">chevrons-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevrons-right-24.svg" alt="chevrons-right" />
+    </div>
+    <div class="icon-card-label">chevrons-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/chevrons-up-24.svg" alt="chevrons-up" />
+    </div>
+    <div class="icon-card-label">chevrons-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-down-left-24.svg" alt="corner-down-left" />
+    </div>
+    <div class="icon-card-label">corner-down-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-down-right-24.svg" alt="corner-down-right" />
+    </div>
+    <div class="icon-card-label">corner-down-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-left-down-24.svg" alt="corner-left-down" />
+    </div>
+    <div class="icon-card-label">corner-left-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-left-up-24.svg" alt="corner-left-up" />
+    </div>
+    <div class="icon-card-label">corner-left-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-right-down-24.svg" alt="corner-right-down" />
+    </div>
+    <div class="icon-card-label">corner-right-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-right-up-24.svg" alt="corner-right-up" />
+    </div>
+    <div class="icon-card-label">corner-right-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-up-left-24.svg" alt="corner-up-left" />
+    </div>
+    <div class="icon-card-label">corner-up-left</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/corner-up-right-24.svg" alt="corner-up-right" />
+    </div>
+    <div class="icon-card-label">corner-up-right</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/load-balancer-24.svg" alt="load-balancer" />
+    </div>
+    <div class="icon-card-label">load-balancer</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/migrate-24.svg" alt="migrate" />
+    </div>
+    <div class="icon-card-label">migrate</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/move-24.svg" alt="move" />
+    </div>
+    <div class="icon-card-label">move</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shuffle-24.svg" alt="shuffle" />
+    </div>
+    <div class="icon-card-label">shuffle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/swap-horizontal-24.svg" alt="swap-horizontal" />
+    </div>
+    <div class="icon-card-label">swap-horizontal</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/swap-vertical-24.svg" alt="swap-vertical" />
+    </div>
+    <div class="icon-card-label">swap-vertical</div>
+  </div>
+</div>
+
+## Communication (33)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/activity-24.svg" alt="activity" />
+    </div>
+    <div class="icon-card-label">activity</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/at-sign-24.svg" alt="at-sign" />
+    </div>
+    <div class="icon-card-label">at-sign</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/award-24.svg" alt="award" />
+    </div>
+    <div class="icon-card-label">award</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bell-24.svg" alt="bell" />
+    </div>
+    <div class="icon-card-label">bell</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bell-active-24.svg" alt="bell-active" />
+    </div>
+    <div class="icon-card-label">bell-active</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bell-active-fill-24.svg" alt="bell-active-fill" />
+    </div>
+    <div class="icon-card-label">bell-active-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bell-off-24.svg" alt="bell-off" />
+    </div>
+    <div class="icon-card-label">bell-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/discussion-circle-24.svg" alt="discussion-circle" />
+    </div>
+    <div class="icon-card-label">discussion-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/discussion-square-24.svg" alt="discussion-square" />
+    </div>
+    <div class="icon-card-label">discussion-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/heart-24.svg" alt="heart" />
+    </div>
+    <div class="icon-card-label">heart</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/heart-fill-24.svg" alt="heart-fill" />
+    </div>
+    <div class="icon-card-label">heart-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/heart-off-24.svg" alt="heart-off" />
+    </div>
+    <div class="icon-card-label">heart-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mail-24.svg" alt="mail" />
+    </div>
+    <div class="icon-card-label">mail</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mail-open-24.svg" alt="mail-open" />
+    </div>
+    <div class="icon-card-label">mail-open</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/message-circle-24.svg" alt="message-circle" />
+    </div>
+    <div class="icon-card-label">message-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/message-circle-fill-24.svg" alt="message-circle-fill" />
+    </div>
+    <div class="icon-card-label">message-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/message-square-24.svg" alt="message-square" />
+    </div>
+    <div class="icon-card-label">message-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/message-square-fill-24.svg" alt="message-square-fill" />
+    </div>
+    <div class="icon-card-label">message-square-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mic-24.svg" alt="mic" />
+    </div>
+    <div class="icon-card-label">mic</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/mic-off-24.svg" alt="mic-off" />
+    </div>
+    <div class="icon-card-label">mic-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/newspaper-24.svg" alt="newspaper" />
+    </div>
+    <div class="icon-card-label">newspaper</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/phone-24.svg" alt="phone" />
+    </div>
+    <div class="icon-card-label">phone</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/phone-call-24.svg" alt="phone-call" />
+    </div>
+    <div class="icon-card-label">phone-call</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/phone-off-24.svg" alt="phone-off" />
+    </div>
+    <div class="icon-card-label">phone-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/send-24.svg" alt="send" />
+    </div>
+    <div class="icon-card-label">send</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/star-24.svg" alt="star" />
+    </div>
+    <div class="icon-card-label">star</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/star-circle-24.svg" alt="star-circle" />
+    </div>
+    <div class="icon-card-label">star-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/star-fill-24.svg" alt="star-fill" />
+    </div>
+    <div class="icon-card-label">star-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/star-off-24.svg" alt="star-off" />
+    </div>
+    <div class="icon-card-label">star-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/thumbs-down-24.svg" alt="thumbs-down" />
+    </div>
+    <div class="icon-card-label">thumbs-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/thumbs-up-24.svg" alt="thumbs-up" />
+    </div>
+    <div class="icon-card-label">thumbs-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/video-24.svg" alt="video" />
+    </div>
+    <div class="icon-card-label">video</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/video-off-24.svg" alt="video-off" />
+    </div>
+    <div class="icon-card-label">video-off</div>
+  </div>
+</div>
+
+## Status (27)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-circle-24.svg" alt="alert-circle" />
+    </div>
+    <div class="icon-card-label">alert-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-circle-fill-24.svg" alt="alert-circle-fill" />
+    </div>
+    <div class="icon-card-label">alert-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-diamond-24.svg" alt="alert-diamond" />
+    </div>
+    <div class="icon-card-label">alert-diamond</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-diamond-fill-24.svg" alt="alert-diamond-fill" />
+    </div>
+    <div class="icon-card-label">alert-diamond-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-octagon-24.svg" alt="alert-octagon" />
+    </div>
+    <div class="icon-card-label">alert-octagon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-octagon-fill-24.svg" alt="alert-octagon-fill" />
+    </div>
+    <div class="icon-card-label">alert-octagon-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-triangle-24.svg" alt="alert-triangle" />
+    </div>
+    <div class="icon-card-label">alert-triangle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/alert-triangle-fill-24.svg" alt="alert-triangle-fill" />
+    </div>
+    <div class="icon-card-label">alert-triangle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-24.svg" alt="check" />
+    </div>
+    <div class="icon-card-label">check</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-circle-24.svg" alt="check-circle" />
+    </div>
+    <div class="icon-card-label">check-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-circle-fill-24.svg" alt="check-circle-fill" />
+    </div>
+    <div class="icon-card-label">check-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-diamond-24.svg" alt="check-diamond" />
+    </div>
+    <div class="icon-card-label">check-diamond</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-diamond-fill-24.svg" alt="check-diamond-fill" />
+    </div>
+    <div class="icon-card-label">check-diamond-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-hexagon-24.svg" alt="check-hexagon" />
+    </div>
+    <div class="icon-card-label">check-hexagon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-hexagon-fill-24.svg" alt="check-hexagon-fill" />
+    </div>
+    <div class="icon-card-label">check-hexagon-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-square-24.svg" alt="check-square" />
+    </div>
+    <div class="icon-card-label">check-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/check-square-fill-24.svg" alt="check-square-fill" />
+    </div>
+    <div class="icon-card-label">check-square-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/skip-24.svg" alt="skip" />
+    </div>
+    <div class="icon-card-label">skip</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-24.svg" alt="x" />
+    </div>
+    <div class="icon-card-label">x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-circle-24.svg" alt="x-circle" />
+    </div>
+    <div class="icon-card-label">x-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-circle-fill-24.svg" alt="x-circle-fill" />
+    </div>
+    <div class="icon-card-label">x-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-diamond-24.svg" alt="x-diamond" />
+    </div>
+    <div class="icon-card-label">x-diamond</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-diamond-fill-24.svg" alt="x-diamond-fill" />
+    </div>
+    <div class="icon-card-label">x-diamond-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-hexagon-24.svg" alt="x-hexagon" />
+    </div>
+    <div class="icon-card-label">x-hexagon</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-hexagon-fill-24.svg" alt="x-hexagon-fill" />
+    </div>
+    <div class="icon-card-label">x-hexagon-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-square-24.svg" alt="x-square" />
+    </div>
+    <div class="icon-card-label">x-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/x-square-fill-24.svg" alt="x-square-fill" />
+    </div>
+    <div class="icon-card-label">x-square-fill</div>
+  </div>
+</div>
+
+## Media (26)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/camera-24.svg" alt="camera" />
+    </div>
+    <div class="icon-card-label">camera</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/camera-off-24.svg" alt="camera-off" />
+    </div>
+    <div class="icon-card-label">camera-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/cast-24.svg" alt="cast" />
+    </div>
+    <div class="icon-card-label">cast</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/closed-caption-24.svg" alt="closed-caption" />
+    </div>
+    <div class="icon-card-label">closed-caption</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/fast-forward-24.svg" alt="fast-forward" />
+    </div>
+    <div class="icon-card-label">fast-forward</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/film-24.svg" alt="film" />
+    </div>
+    <div class="icon-card-label">film</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/headphones-24.svg" alt="headphones" />
+    </div>
+    <div class="icon-card-label">headphones</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/image-24.svg" alt="image" />
+    </div>
+    <div class="icon-card-label">image</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/music-24.svg" alt="music" />
+    </div>
+    <div class="icon-card-label">music</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pause-24.svg" alt="pause" />
+    </div>
+    <div class="icon-card-label">pause</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pause-circle-24.svg" alt="pause-circle" />
+    </div>
+    <div class="icon-card-label">pause-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/play-24.svg" alt="play" />
+    </div>
+    <div class="icon-card-label">play</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/play-circle-24.svg" alt="play-circle" />
+    </div>
+    <div class="icon-card-label">play-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/radio-24.svg" alt="radio" />
+    </div>
+    <div class="icon-card-label">radio</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rewind-24.svg" alt="rewind" />
+    </div>
+    <div class="icon-card-label">rewind</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/rss-24.svg" alt="rss" />
+    </div>
+    <div class="icon-card-label">rss</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/skip-back-24.svg" alt="skip-back" />
+    </div>
+    <div class="icon-card-label">skip-back</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/skip-forward-24.svg" alt="skip-forward" />
+    </div>
+    <div class="icon-card-label">skip-forward</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/speaker-24.svg" alt="speaker" />
+    </div>
+    <div class="icon-card-label">speaker</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/stop-circle-24.svg" alt="stop-circle" />
+    </div>
+    <div class="icon-card-label">stop-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/volume-24.svg" alt="volume" />
+    </div>
+    <div class="icon-card-label">volume</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/volume-down-24.svg" alt="volume-down" />
+    </div>
+    <div class="icon-card-label">volume-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/volume-up-24.svg" alt="volume-up" />
+    </div>
+    <div class="icon-card-label">volume-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/volume-x-24.svg" alt="volume-x" />
+    </div>
+    <div class="icon-card-label">volume-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/wifi-24.svg" alt="wifi" />
+    </div>
+    <div class="icon-card-label">wifi</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/wifi-off-24.svg" alt="wifi-off" />
+    </div>
+    <div class="icon-card-label">wifi-off</div>
+  </div>
+</div>
+
+## Files (23)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/archive-24.svg" alt="archive" />
+    </div>
+    <div class="icon-card-label">archive</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clipboard-24.svg" alt="clipboard" />
+    </div>
+    <div class="icon-card-label">clipboard</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clipboard-checked-24.svg" alt="clipboard-checked" />
+    </div>
+    <div class="icon-card-label">clipboard-checked</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clipboard-copy-24.svg" alt="clipboard-copy" />
+    </div>
+    <div class="icon-card-label">clipboard-copy</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clipboard-x-24.svg" alt="clipboard-x" />
+    </div>
+    <div class="icon-card-label">clipboard-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-24.svg" alt="file" />
+    </div>
+    <div class="icon-card-label">file</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-change-24.svg" alt="file-change" />
+    </div>
+    <div class="icon-card-label">file-change</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-check-24.svg" alt="file-check" />
+    </div>
+    <div class="icon-card-label">file-check</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-diff-24.svg" alt="file-diff" />
+    </div>
+    <div class="icon-card-label">file-diff</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-minus-24.svg" alt="file-minus" />
+    </div>
+    <div class="icon-card-label">file-minus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-plus-24.svg" alt="file-plus" />
+    </div>
+    <div class="icon-card-label">file-plus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-source-24.svg" alt="file-source" />
+    </div>
+    <div class="icon-card-label">file-source</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-text-24.svg" alt="file-text" />
+    </div>
+    <div class="icon-card-label">file-text</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/file-x-24.svg" alt="file-x" />
+    </div>
+    <div class="icon-card-label">file-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/files-24.svg" alt="files" />
+    </div>
+    <div class="icon-card-label">files</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-24.svg" alt="folder" />
+    </div>
+    <div class="icon-card-label">folder</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-fill-24.svg" alt="folder-fill" />
+    </div>
+    <div class="icon-card-label">folder-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-minus-24.svg" alt="folder-minus" />
+    </div>
+    <div class="icon-card-label">folder-minus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-minus-fill-24.svg" alt="folder-minus-fill" />
+    </div>
+    <div class="icon-card-label">folder-minus-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-plus-24.svg" alt="folder-plus" />
+    </div>
+    <div class="icon-card-label">folder-plus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-plus-fill-24.svg" alt="folder-plus-fill" />
+    </div>
+    <div class="icon-card-label">folder-plus-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-star-24.svg" alt="folder-star" />
+    </div>
+    <div class="icon-card-label">folder-star</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/inbox-24.svg" alt="inbox" />
+    </div>
+    <div class="icon-card-label">inbox</div>
+  </div>
+</div>
+
+## Security (19)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bug-24.svg" alt="bug" />
+    </div>
+    <div class="icon-card-label">bug</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/certificate-24.svg" alt="certificate" />
+    </div>
+    <div class="icon-card-label">certificate</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/eye-24.svg" alt="eye" />
+    </div>
+    <div class="icon-card-label">eye</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/eye-off-24.svg" alt="eye-off" />
+    </div>
+    <div class="icon-card-label">eye-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/fingerprint-24.svg" alt="fingerprint" />
+    </div>
+    <div class="icon-card-label">fingerprint</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/key-24.svg" alt="key" />
+    </div>
+    <div class="icon-card-label">key</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/keychain-24.svg" alt="keychain" />
+    </div>
+    <div class="icon-card-label">keychain</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/lock-24.svg" alt="lock" />
+    </div>
+    <div class="icon-card-label">lock</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/lock-fill-24.svg" alt="lock-fill" />
+    </div>
+    <div class="icon-card-label">lock-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/lock-off-24.svg" alt="lock-off" />
+    </div>
+    <div class="icon-card-label">lock-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shield-24.svg" alt="shield" />
+    </div>
+    <div class="icon-card-label">shield</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shield-alert-24.svg" alt="shield-alert" />
+    </div>
+    <div class="icon-card-label">shield-alert</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shield-check-24.svg" alt="shield-check" />
+    </div>
+    <div class="icon-card-label">shield-check</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shield-off-24.svg" alt="shield-off" />
+    </div>
+    <div class="icon-card-label">shield-off</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shield-x-24.svg" alt="shield-x" />
+    </div>
+    <div class="icon-card-label">shield-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/token-24.svg" alt="token" />
+    </div>
+    <div class="icon-card-label">token</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/unlock-24.svg" alt="unlock" />
+    </div>
+    <div class="icon-card-label">unlock</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/verified-24.svg" alt="verified" />
+    </div>
+    <div class="icon-card-label">verified</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/wall-24.svg" alt="wall" />
+    </div>
+    <div class="icon-card-label">wall</div>
+  </div>
+</div>
+
+## User (16)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/accessibility-24.svg" alt="accessibility" />
+    </div>
+    <div class="icon-card-label">accessibility</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/folder-users-24.svg" alt="folder-users" />
+    </div>
+    <div class="icon-card-label">folder-users</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/frown-24.svg" alt="frown" />
+    </div>
+    <div class="icon-card-label">frown</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/identity-service-24.svg" alt="identity-service" />
+    </div>
+    <div class="icon-card-label">identity-service</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/identity-user-24.svg" alt="identity-user" />
+    </div>
+    <div class="icon-card-label">identity-user</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/meh-24.svg" alt="meh" />
+    </div>
+    <div class="icon-card-label">meh</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/robot-24.svg" alt="robot" />
+    </div>
+    <div class="icon-card-label">robot</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/smile-24.svg" alt="smile" />
+    </div>
+    <div class="icon-card-label">smile</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-24.svg" alt="user" />
+    </div>
+    <div class="icon-card-label">user</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-check-24.svg" alt="user-check" />
+    </div>
+    <div class="icon-card-label">user-check</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-circle-24.svg" alt="user-circle" />
+    </div>
+    <div class="icon-card-label">user-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-circle-fill-24.svg" alt="user-circle-fill" />
+    </div>
+    <div class="icon-card-label">user-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-minus-24.svg" alt="user-minus" />
+    </div>
+    <div class="icon-card-label">user-minus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-plus-24.svg" alt="user-plus" />
+    </div>
+    <div class="icon-card-label">user-plus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/user-x-24.svg" alt="user-x" />
+    </div>
+    <div class="icon-card-label">user-x</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/users-24.svg" alt="users" />
+    </div>
+    <div class="icon-card-label">users</div>
+  </div>
+</div>
+
+## Data (15)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bar-chart-24.svg" alt="bar-chart" />
+    </div>
+    <div class="icon-card-label">bar-chart</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bar-chart-alt-24.svg" alt="bar-chart-alt" />
+    </div>
+    <div class="icon-card-label">bar-chart-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/box-24.svg" alt="box" />
+    </div>
+    <div class="icon-card-label">box</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/collections-24.svg" alt="collections" />
+    </div>
+    <div class="icon-card-label">collections</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/database-24.svg" alt="database" />
+    </div>
+    <div class="icon-card-label">database</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hard-drive-24.svg" alt="hard-drive" />
+    </div>
+    <div class="icon-card-label">hard-drive</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/line-chart-24.svg" alt="line-chart" />
+    </div>
+    <div class="icon-card-label">line-chart</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/line-chart-up-24.svg" alt="line-chart-up" />
+    </div>
+    <div class="icon-card-label">line-chart-up</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/logs-24.svg" alt="logs" />
+    </div>
+    <div class="icon-card-label">logs</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/package-24.svg" alt="package" />
+    </div>
+    <div class="icon-card-label">package</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/pie-chart-24.svg" alt="pie-chart" />
+    </div>
+    <div class="icon-card-label">pie-chart</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/queue-24.svg" alt="queue" />
+    </div>
+    <div class="icon-card-label">queue</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/save-24.svg" alt="save" />
+    </div>
+    <div class="icon-card-label">save</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/trend-down-24.svg" alt="trend-down" />
+    </div>
+    <div class="icon-card-label">trend-down</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/trend-up-24.svg" alt="trend-up" />
+    </div>
+    <div class="icon-card-label">trend-up</div>
+  </div>
+</div>
+
+## Operations (12)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-24.svg" alt="minus" />
+    </div>
+    <div class="icon-card-label">minus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-circle-24.svg" alt="minus-circle" />
+    </div>
+    <div class="icon-card-label">minus-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-circle-fill-24.svg" alt="minus-circle-fill" />
+    </div>
+    <div class="icon-card-label">minus-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-plus-24.svg" alt="minus-plus" />
+    </div>
+    <div class="icon-card-label">minus-plus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-plus-circle-24.svg" alt="minus-plus-circle" />
+    </div>
+    <div class="icon-card-label">minus-plus-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-plus-square-24.svg" alt="minus-plus-square" />
+    </div>
+    <div class="icon-card-label">minus-plus-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-square-24.svg" alt="minus-square" />
+    </div>
+    <div class="icon-card-label">minus-square</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/minus-square-fill-24.svg" alt="minus-square-fill" />
+    </div>
+    <div class="icon-card-label">minus-square-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/plus-24.svg" alt="plus" />
+    </div>
+    <div class="icon-card-label">plus</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/plus-circle-24.svg" alt="plus-circle" />
+    </div>
+    <div class="icon-card-label">plus-circle</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/plus-circle-fill-24.svg" alt="plus-circle-fill" />
+    </div>
+    <div class="icon-card-label">plus-circle-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/plus-square-24.svg" alt="plus-square" />
+    </div>
+    <div class="icon-card-label">plus-square</div>
+  </div>
+</div>
+
+## Business (11)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/bank-vault-24.svg" alt="bank-vault" />
+    </div>
+    <div class="icon-card-label">bank-vault</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/briefcase-24.svg" alt="briefcase" />
+    </div>
+    <div class="icon-card-label">briefcase</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/credit-card-24.svg" alt="credit-card" />
+    </div>
+    <div class="icon-card-label">credit-card</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/dollar-sign-24.svg" alt="dollar-sign" />
+    </div>
+    <div class="icon-card-label">dollar-sign</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/enterprise-24.svg" alt="enterprise" />
+    </div>
+    <div class="icon-card-label">enterprise</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/globe-24.svg" alt="globe" />
+    </div>
+    <div class="icon-card-label">globe</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/globe-private-24.svg" alt="globe-private" />
+    </div>
+    <div class="icon-card-label">globe-private</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/org-24.svg" alt="org" />
+    </div>
+    <div class="icon-card-label">org</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/provider-24.svg" alt="provider" />
+    </div>
+    <div class="icon-card-label">provider</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shopping-bag-24.svg" alt="shopping-bag" />
+    </div>
+    <div class="icon-card-label">shopping-bag</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/shopping-cart-24.svg" alt="shopping-cart" />
+    </div>
+    <div class="icon-card-label">shopping-cart</div>
+  </div>
+</div>
+
+## Support (11)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/docs-24.svg" alt="docs" />
+    </div>
+    <div class="icon-card-label">docs</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/docs-download-24.svg" alt="docs-download" />
+    </div>
+    <div class="icon-card-label">docs-download</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/docs-link-24.svg" alt="docs-link" />
+    </div>
+    <div class="icon-card-label">docs-link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/guide-24.svg" alt="guide" />
+    </div>
+    <div class="icon-card-label">guide</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/guide-link-24.svg" alt="guide-link" />
+    </div>
+    <div class="icon-card-label">guide-link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/help-24.svg" alt="help" />
+    </div>
+    <div class="icon-card-label">help</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/info-24.svg" alt="info" />
+    </div>
+    <div class="icon-card-label">info</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/info-fill-24.svg" alt="info-fill" />
+    </div>
+    <div class="icon-card-label">info-fill</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/learn-24.svg" alt="learn" />
+    </div>
+    <div class="icon-card-label">learn</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/learn-link-24.svg" alt="learn-link" />
+    </div>
+    <div class="icon-card-label">learn-link</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/support-24.svg" alt="support" />
+    </div>
+    <div class="icon-card-label">support</div>
+  </div>
+</div>
+
+## Date and time (8)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/calendar-24.svg" alt="calendar" />
+    </div>
+    <div class="icon-card-label">calendar</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clock-24.svg" alt="clock" />
+    </div>
+    <div class="icon-card-label">clock</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/clock-filled-24.svg" alt="clock-filled" />
+    </div>
+    <div class="icon-card-label">clock-filled</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/delay-24.svg" alt="delay" />
+    </div>
+    <div class="icon-card-label">delay</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/event-24.svg" alt="event" />
+    </div>
+    <div class="icon-card-label">event</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/history-24.svg" alt="history" />
+    </div>
+    <div class="icon-card-label">history</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/hourglass-24.svg" alt="hourglass" />
+    </div>
+    <div class="icon-card-label">hourglass</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/watch-24.svg" alt="watch" />
+    </div>
+    <div class="icon-card-label">watch</div>
+  </div>
+</div>
+
+## Location (8)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/compass-24.svg" alt="compass" />
+    </div>
+    <div class="icon-card-label">compass</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/crosshair-24.svg" alt="crosshair" />
+    </div>
+    <div class="icon-card-label">crosshair</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/map-24.svg" alt="map" />
+    </div>
+    <div class="icon-card-label">map</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/map-pin-24.svg" alt="map-pin" />
+    </div>
+    <div class="icon-card-label">map-pin</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/navigation-24.svg" alt="navigation" />
+    </div>
+    <div class="icon-card-label">navigation</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/navigation-alt-24.svg" alt="navigation-alt" />
+    </div>
+    <div class="icon-card-label">navigation-alt</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/redirect-24.svg" alt="redirect" />
+    </div>
+    <div class="icon-card-label">redirect</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/target-24.svg" alt="target" />
+    </div>
+    <div class="icon-card-label">target</div>
+  </div>
+</div>
+
+## Animated (4)
+
+<div class="icon-grid">
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/loading-24.svg" alt="loading" />
+    </div>
+    <div class="icon-card-label">loading</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/loading-static-24.svg" alt="loading-static" />
+    </div>
+    <div class="icon-card-label">loading-static</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/running-24.svg" alt="running" />
+    </div>
+    <div class="icon-card-label">running</div>
+  </div>
+  <div class="icon-card">
+    <div class="icon-card-image">
+      <img src="https://cdn.jsdelivr.net/npm/@hashicorp/flight-icons@latest/svg/running-static-24.svg" alt="running-static" />
+    </div>
+    <div class="icon-card-label">running-static</div>
+  </div>
+</div>

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -325,7 +325,7 @@ Seti icons use the `seti:` prefix and are designed for file-type representation.
 
 ## Community Icon Packs
 
-The built-in icons cover common needs, but additional icon packs can be integrated into the `docs-builder` for broader coverage. These are not installed by default — content authors can request additions by opening an issue in the `docs-builder` repository.
+The built-in icons cover common needs, but additional icon packs can be integrated into the `docs-builder` for broader coverage. These are not installed by default — adding them is tracked in [docs-builder issue #80](https://github.com/f5xc-salesdemos/docs-builder/issues/80).
 
 ### astro-icon + Iconify
 
@@ -358,12 +358,13 @@ import { Rocket, Database, Shield } from 'lucide-astro';
 
 ## HashiCorp Flight Icons
 
-The [`@hashicorp/flight-icons`](https://github.com/hashicorp/design-system/tree/main/packages/flight-icons) package provides approximately 2,700 icons covering networking, security, cloud, and infrastructure domains — relevant for F5 and multi-cloud documentation.
+The [`@hashicorp/flight-icons`](https://github.com/hashicorp/design-system/tree/main/packages/flight-icons) package provides 671 icons (at 24px) covering networking, security, cloud, and infrastructure domains — relevant for F5 and multi-cloud documentation.
 
 - **License**: MPL-2.0 (permissive, can be used in non-HashiCorp projects)
 - **Format**: SVG sprites and individual SVGs
-- **Status**: Not currently installed in docs-builder
+- **Status**: Not currently installed in docs-builder — available via CDN for reference
+- **Visual reference**: See the [HashiCorp Flight Icons](/hashicorp-icons/) page for every icon organized by category
 
 :::note
-To use community icon packs or HashiCorp Flight icons, open an issue in the [`docs-builder`](https://github.com/f5xc-salesdemos/docs-builder) repository requesting the package be added to the build container.
+Adding community icon packs and HashiCorp Flight icons to the docs-builder container is tracked in [docs-builder issue #80](https://github.com/f5xc-salesdemos/docs-builder/issues/80).
 :::

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -429,6 +429,11 @@ h4, h5, h6 {
   filter: invert(1);
 }
 
+/* Preserve original colors for branded/color-variant icons in dark mode */
+:root:not([data-theme='light']) .icon-card-image.no-invert img {
+  filter: none;
+}
+
 .icon-card-label {
   margin: 0;
   padding: 0.375rem 0.5rem;


### PR DESCRIPTION
## Summary
- Add dedicated `docs/hashicorp-icons.mdx` page showing all 671 HashiCorp Flight icons organized by 19 categories, rendered via jsDelivr CDN `<img>` tags
- Add `.no-invert` CSS utility class so color-variant icons preserve branded colors in dark mode (monochrome icons continue to auto-invert)
- Update `docs/icons.mdx` with cross-reference link to the new page and reference to docs-builder issue #80

Closes #81

## Test plan
- [ ] Verify page builds without errors in docs-builder container
- [ ] Spot-check icon rendering across several categories (Services, Products, Interface)
- [ ] Confirm monochrome icons invert correctly in dark mode
- [ ] Confirm `-color` variant icons retain original colors in dark mode
- [ ] Verify sidebar shows "HashiCorp Flight Icons" at position 14
- [ ] Verify cross-reference links work from icons.mdx to hashicorp-icons.mdx

🤖 Generated with [Claude Code](https://claude.com/claude-code)