### PR TITLE
fix: Iconify icons not rendering on Lucide and Iconify Packs pages

### DIFF
--- a/docs/icons/iconify-packs.mdx
+++ b/docs/icons/iconify-packs.mdx
@@ -1,146 +1,148 @@
 ---
 title: Iconify Packs
-description: Curated reference for Material Design, Carbon, Phosphor, and Tabler icon packs available via the Icon component.
+description: Curated reference for Material Design, Carbon, Phosphor, and Tabler icon packs available via the Iconify API.
 sidebar:
   label: Iconify Packs
   order: 5
 ---
 
-import { Icon } from '@astrojs/starlight/components';
-
-Multiple Iconify icon packs are installed in the docs-builder container. All use the same `<Icon>` component with a pack-specific prefix.
+Multiple Iconify icon packs are installed in the docs-builder container. All use `<img>` tags referencing the Iconify API with a pack-specific prefix.
 
 ## Pack Comparison
 
 | Pack | Prefix | Icons | Style | Best For |
 |------|--------|-------|-------|----------|
-| Material Design | `mdi:` | 7,000+ | Filled + outlined | General-purpose, broadest coverage |
-| Carbon | `carbon:` | ~1,500 | Outlined | Enterprise/IBM design, clean lines |
-| Phosphor | `ph:` | ~1,200 | Multiple weights | Flexible weight options (thin to fill) |
-| Tabler | `tabler:` | ~4,500 | Stroke-based | Crisp line icons, consistent stroke |
+| Material Design | `mdi` | 7,000+ | Filled + outlined | General-purpose, broadest coverage |
+| Carbon | `carbon` | ~1,500 | Outlined | Enterprise/IBM design, clean lines |
+| Phosphor | `ph` | ~1,200 | Multiple weights | Flexible weight options (thin to fill) |
+| Tabler | `tabler` | ~4,500 | Stroke-based | Crisp line icons, consistent stroke |
 
 ## Usage
 
-All packs share the same syntax:
+All packs share the same `<img>` syntax pattern:
 
 ```mdx
-import { Icon } from '@astrojs/starlight/components';
-
-<Icon name="mdi:database" />
-<Icon name="carbon:cloud" />
-<Icon name="ph:globe" />
-<Icon name="tabler:shield" />
+<img src="https://api.iconify.design/mdi/database.svg" alt="database" width="24" height="24" />
+<img src="https://api.iconify.design/carbon/cloud.svg" alt="cloud" width="24" height="24" />
+<img src="https://api.iconify.design/ph/globe.svg" alt="globe" width="24" height="24" />
+<img src="https://api.iconify.design/tabler/shield.svg" alt="shield" width="24" height="24" />
 ```
 
-Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
+Wrap in `.icon-card-image` for automatic dark mode inversion:
 
-## Material Design Icons (mdi:)
+```mdx
+<div class="icon-card-image" style="display:inline-flex;">
+  <img src="https://api.iconify.design/mdi/database.svg" alt="database" width="24" height="24" />
+</div>
+```
+
+## Material Design Icons (mdi)
 
 The largest icon pack with 7,000+ icons covering virtually every use case.
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:database" size="1.5rem" /></div><div class="icon-card-label">mdi:database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:cloud" size="1.5rem" /></div><div class="icon-card-label">mdi:cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:server" size="1.5rem" /></div><div class="icon-card-label">mdi:server</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:shield-lock" size="1.5rem" /></div><div class="icon-card-label">mdi:shield-lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:fire" size="1.5rem" /></div><div class="icon-card-label">mdi:fire</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:account" size="1.5rem" /></div><div class="icon-card-label">mdi:account</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:cog" size="1.5rem" /></div><div class="icon-card-label">mdi:cog</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:chart-bar" size="1.5rem" /></div><div class="icon-card-label">mdi:chart-bar</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:network" size="1.5rem" /></div><div class="icon-card-label">mdi:network</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:lock" size="1.5rem" /></div><div class="icon-card-label">mdi:lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:key" size="1.5rem" /></div><div class="icon-card-label">mdi:key</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:web" size="1.5rem" /></div><div class="icon-card-label">mdi:web</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:api" size="1.5rem" /></div><div class="icon-card-label">mdi:api</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:dns" size="1.5rem" /></div><div class="icon-card-label">mdi:dns</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:kubernetes" size="1.5rem" /></div><div class="icon-card-label">mdi:kubernetes</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:docker" size="1.5rem" /></div><div class="icon-card-label">mdi:docker</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:terraform" size="1.5rem" /></div><div class="icon-card-label">mdi:terraform</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:console" size="1.5rem" /></div><div class="icon-card-label">mdi:console</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:memory" size="1.5rem" /></div><div class="icon-card-label">mdi:memory</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:monitor-dashboard" size="1.5rem" /></div><div class="icon-card-label">mdi:monitor-dashboard</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:robot" size="1.5rem" /></div><div class="icon-card-label">mdi:robot</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:earth" size="1.5rem" /></div><div class="icon-card-label">mdi:earth</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:lan" size="1.5rem" /></div><div class="icon-card-label">mdi:lan</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:access-point" size="1.5rem" /></div><div class="icon-card-label">mdi:access-point</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:alert" size="1.5rem" /></div><div class="icon-card-label">mdi:alert</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:check-circle" size="1.5rem" /></div><div class="icon-card-label">mdi:check-circle</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:code-tags" size="1.5rem" /></div><div class="icon-card-label">mdi:code-tags</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:file-document" size="1.5rem" /></div><div class="icon-card-label">mdi:file-document</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:github" size="1.5rem" /></div><div class="icon-card-label">mdi:github</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="mdi:lightning-bolt" size="1.5rem" /></div><div class="icon-card-label">mdi:lightning-bolt</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/database.svg" alt="database" width="24" height="24" /></div><div class="icon-card-label">mdi/database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">mdi/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/server.svg" alt="server" width="24" height="24" /></div><div class="icon-card-label">mdi/server</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/shield-lock.svg" alt="shield-lock" width="24" height="24" /></div><div class="icon-card-label">mdi/shield-lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/fire.svg" alt="fire" width="24" height="24" /></div><div class="icon-card-label">mdi/fire</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/account.svg" alt="account" width="24" height="24" /></div><div class="icon-card-label">mdi/account</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/cog.svg" alt="cog" width="24" height="24" /></div><div class="icon-card-label">mdi/cog</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/chart-bar.svg" alt="chart-bar" width="24" height="24" /></div><div class="icon-card-label">mdi/chart-bar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/network.svg" alt="network" width="24" height="24" /></div><div class="icon-card-label">mdi/network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/lock.svg" alt="lock" width="24" height="24" /></div><div class="icon-card-label">mdi/lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/key.svg" alt="key" width="24" height="24" /></div><div class="icon-card-label">mdi/key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/web.svg" alt="web" width="24" height="24" /></div><div class="icon-card-label">mdi/web</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/api.svg" alt="api" width="24" height="24" /></div><div class="icon-card-label">mdi/api</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/dns.svg" alt="dns" width="24" height="24" /></div><div class="icon-card-label">mdi/dns</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/kubernetes.svg" alt="kubernetes" width="24" height="24" /></div><div class="icon-card-label">mdi/kubernetes</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/docker.svg" alt="docker" width="24" height="24" /></div><div class="icon-card-label">mdi/docker</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/terraform.svg" alt="terraform" width="24" height="24" /></div><div class="icon-card-label">mdi/terraform</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/console.svg" alt="console" width="24" height="24" /></div><div class="icon-card-label">mdi/console</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/memory.svg" alt="memory" width="24" height="24" /></div><div class="icon-card-label">mdi/memory</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/monitor-dashboard.svg" alt="monitor-dashboard" width="24" height="24" /></div><div class="icon-card-label">mdi/monitor-dashboard</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/robot.svg" alt="robot" width="24" height="24" /></div><div class="icon-card-label">mdi/robot</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/earth.svg" alt="earth" width="24" height="24" /></div><div class="icon-card-label">mdi/earth</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/lan.svg" alt="lan" width="24" height="24" /></div><div class="icon-card-label">mdi/lan</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/access-point.svg" alt="access-point" width="24" height="24" /></div><div class="icon-card-label">mdi/access-point</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/alert.svg" alt="alert" width="24" height="24" /></div><div class="icon-card-label">mdi/alert</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/check-circle.svg" alt="check-circle" width="24" height="24" /></div><div class="icon-card-label">mdi/check-circle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/code-tags.svg" alt="code-tags" width="24" height="24" /></div><div class="icon-card-label">mdi/code-tags</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/file-document.svg" alt="file-document" width="24" height="24" /></div><div class="icon-card-label">mdi/file-document</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/github.svg" alt="github" width="24" height="24" /></div><div class="icon-card-label">mdi/github</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/lightning-bolt.svg" alt="lightning-bolt" width="24" height="24" /></div><div class="icon-card-label">mdi/lightning-bolt</div></div>
 </div>
 
 Browse all: [Iconify MDI explorer](https://icon-sets.iconify.design/mdi/)
 
-## Carbon Icons (carbon:)
+## Carbon Icons (carbon)
 
 IBM's enterprise design language with ~1,500 clean, outlined icons.
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:cloud" size="1.5rem" /></div><div class="icon-card-label">carbon:cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:security" size="1.5rem" /></div><div class="icon-card-label">carbon:security</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:network-3" size="1.5rem" /></div><div class="icon-card-label">carbon:network-3</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:data-base" size="1.5rem" /></div><div class="icon-card-label">carbon:data-base</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:application" size="1.5rem" /></div><div class="icon-card-label">carbon:application</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:api" size="1.5rem" /></div><div class="icon-card-label">carbon:api</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:dashboard" size="1.5rem" /></div><div class="icon-card-label">carbon:dashboard</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:terminal" size="1.5rem" /></div><div class="icon-card-label">carbon:terminal</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:code" size="1.5rem" /></div><div class="icon-card-label">carbon:code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:user" size="1.5rem" /></div><div class="icon-card-label">carbon:user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:settings" size="1.5rem" /></div><div class="icon-card-label">carbon:settings</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:document" size="1.5rem" /></div><div class="icon-card-label">carbon:document</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:earth" size="1.5rem" /></div><div class="icon-card-label">carbon:earth</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:warning" size="1.5rem" /></div><div class="icon-card-label">carbon:warning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="carbon:checkmark" size="1.5rem" /></div><div class="icon-card-label">carbon:checkmark</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">carbon/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/security.svg" alt="security" width="24" height="24" /></div><div class="icon-card-label">carbon/security</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/network-3.svg" alt="network-3" width="24" height="24" /></div><div class="icon-card-label">carbon/network-3</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/data-base.svg" alt="data-base" width="24" height="24" /></div><div class="icon-card-label">carbon/data-base</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/application.svg" alt="application" width="24" height="24" /></div><div class="icon-card-label">carbon/application</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/api.svg" alt="api" width="24" height="24" /></div><div class="icon-card-label">carbon/api</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/dashboard.svg" alt="dashboard" width="24" height="24" /></div><div class="icon-card-label">carbon/dashboard</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/terminal.svg" alt="terminal" width="24" height="24" /></div><div class="icon-card-label">carbon/terminal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/code.svg" alt="code" width="24" height="24" /></div><div class="icon-card-label">carbon/code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/user.svg" alt="user" width="24" height="24" /></div><div class="icon-card-label">carbon/user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/settings.svg" alt="settings" width="24" height="24" /></div><div class="icon-card-label">carbon/settings</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/document.svg" alt="document" width="24" height="24" /></div><div class="icon-card-label">carbon/document</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/earth.svg" alt="earth" width="24" height="24" /></div><div class="icon-card-label">carbon/earth</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/warning.svg" alt="warning" width="24" height="24" /></div><div class="icon-card-label">carbon/warning</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/checkmark.svg" alt="checkmark" width="24" height="24" /></div><div class="icon-card-label">carbon/checkmark</div></div>
 </div>
 
 Browse all: [Iconify Carbon explorer](https://icon-sets.iconify.design/carbon/)
 
-## Phosphor Icons (ph:)
+## Phosphor Icons (ph)
 
 ~1,200 icons with flexible weight options — thin, light, regular, bold, fill, and duotone.
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:globe" size="1.5rem" /></div><div class="icon-card-label">ph:globe</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:shield" size="1.5rem" /></div><div class="icon-card-label">ph:shield</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:cloud" size="1.5rem" /></div><div class="icon-card-label">ph:cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:database" size="1.5rem" /></div><div class="icon-card-label">ph:database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:lock" size="1.5rem" /></div><div class="icon-card-label">ph:lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:user" size="1.5rem" /></div><div class="icon-card-label">ph:user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:gear" size="1.5rem" /></div><div class="icon-card-label">ph:gear</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:code" size="1.5rem" /></div><div class="icon-card-label">ph:code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:terminal-window" size="1.5rem" /></div><div class="icon-card-label">ph:terminal-window</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:rocket" size="1.5rem" /></div><div class="icon-card-label">ph:rocket</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:lightning" size="1.5rem" /></div><div class="icon-card-label">ph:lightning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:chart-bar" size="1.5rem" /></div><div class="icon-card-label">ph:chart-bar</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:file" size="1.5rem" /></div><div class="icon-card-label">ph:file</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:warning" size="1.5rem" /></div><div class="icon-card-label">ph:warning</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="ph:check-circle" size="1.5rem" /></div><div class="icon-card-label">ph:check-circle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/globe.svg" alt="globe" width="24" height="24" /></div><div class="icon-card-label">ph/globe</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/shield.svg" alt="shield" width="24" height="24" /></div><div class="icon-card-label">ph/shield</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">ph/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/database.svg" alt="database" width="24" height="24" /></div><div class="icon-card-label">ph/database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/lock.svg" alt="lock" width="24" height="24" /></div><div class="icon-card-label">ph/lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/user.svg" alt="user" width="24" height="24" /></div><div class="icon-card-label">ph/user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/gear.svg" alt="gear" width="24" height="24" /></div><div class="icon-card-label">ph/gear</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/code.svg" alt="code" width="24" height="24" /></div><div class="icon-card-label">ph/code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/terminal-window.svg" alt="terminal-window" width="24" height="24" /></div><div class="icon-card-label">ph/terminal-window</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/rocket.svg" alt="rocket" width="24" height="24" /></div><div class="icon-card-label">ph/rocket</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/lightning.svg" alt="lightning" width="24" height="24" /></div><div class="icon-card-label">ph/lightning</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/chart-bar.svg" alt="chart-bar" width="24" height="24" /></div><div class="icon-card-label">ph/chart-bar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/file.svg" alt="file" width="24" height="24" /></div><div class="icon-card-label">ph/file</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/warning.svg" alt="warning" width="24" height="24" /></div><div class="icon-card-label">ph/warning</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/ph/check-circle.svg" alt="check-circle" width="24" height="24" /></div><div class="icon-card-label">ph/check-circle</div></div>
 </div>
 
 Browse all: [Iconify Phosphor explorer](https://icon-sets.iconify.design/ph/)
 
-## Tabler Icons (tabler:)
+## Tabler Icons (tabler)
 
 ~4,500 crisp line icons with consistent 2px stroke width.
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:shield" size="1.5rem" /></div><div class="icon-card-label">tabler:shield</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:cloud" size="1.5rem" /></div><div class="icon-card-label">tabler:cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:database" size="1.5rem" /></div><div class="icon-card-label">tabler:database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:server" size="1.5rem" /></div><div class="icon-card-label">tabler:server</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:network" size="1.5rem" /></div><div class="icon-card-label">tabler:network</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:lock" size="1.5rem" /></div><div class="icon-card-label">tabler:lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:key" size="1.5rem" /></div><div class="icon-card-label">tabler:key</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:code" size="1.5rem" /></div><div class="icon-card-label">tabler:code</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:terminal" size="1.5rem" /></div><div class="icon-card-label">tabler:terminal</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:globe" size="1.5rem" /></div><div class="icon-card-label">tabler:globe</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:user" size="1.5rem" /></div><div class="icon-card-label">tabler:user</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:settings" size="1.5rem" /></div><div class="icon-card-label">tabler:settings</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:rocket" size="1.5rem" /></div><div class="icon-card-label">tabler:rocket</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:bolt" size="1.5rem" /></div><div class="icon-card-label">tabler:bolt</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="tabler:chart-bar" size="1.5rem" /></div><div class="icon-card-label">tabler:chart-bar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/shield.svg" alt="shield" width="24" height="24" /></div><div class="icon-card-label">tabler/shield</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">tabler/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/database.svg" alt="database" width="24" height="24" /></div><div class="icon-card-label">tabler/database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/server.svg" alt="server" width="24" height="24" /></div><div class="icon-card-label">tabler/server</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/network.svg" alt="network" width="24" height="24" /></div><div class="icon-card-label">tabler/network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/lock.svg" alt="lock" width="24" height="24" /></div><div class="icon-card-label">tabler/lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/key.svg" alt="key" width="24" height="24" /></div><div class="icon-card-label">tabler/key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/code.svg" alt="code" width="24" height="24" /></div><div class="icon-card-label">tabler/code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/terminal.svg" alt="terminal" width="24" height="24" /></div><div class="icon-card-label">tabler/terminal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/world.svg" alt="world" width="24" height="24" /></div><div class="icon-card-label">tabler/world</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/user.svg" alt="user" width="24" height="24" /></div><div class="icon-card-label">tabler/user</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/settings.svg" alt="settings" width="24" height="24" /></div><div class="icon-card-label">tabler/settings</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/rocket.svg" alt="rocket" width="24" height="24" /></div><div class="icon-card-label">tabler/rocket</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/bolt.svg" alt="bolt" width="24" height="24" /></div><div class="icon-card-label">tabler/bolt</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/chart-bar.svg" alt="chart-bar" width="24" height="24" /></div><div class="icon-card-label">tabler/chart-bar</div></div>
 </div>
 
 Browse all: [Iconify Tabler explorer](https://icon-sets.iconify.design/tabler/)

--- a/docs/icons/index.mdx
+++ b/docs/icons/index.mdx
@@ -8,7 +8,7 @@ sidebar:
 
 import { Icon } from '@astrojs/starlight/components';
 
-The documentation theme provides access to thousands of icons from multiple packs. Icons can be used in MDX content via the `<Icon>` component or as `<img>` tags referencing SVG files.
+The documentation theme provides access to thousands of icons from multiple packs. Icons can be used in MDX content via the `<Icon>` component, `<img>` tags referencing SVG files, or `<img>` tags referencing the Iconify API.
 
 ## Available Icon Packs
 
@@ -16,27 +16,27 @@ The documentation theme provides access to thousands of icons from multiple pack
 |------|-------|-------|------|
 | Starlight Built-in | ~200 | `<Icon name="star" />` | [Starlight Built-in](/icons/starlight/) |
 | F5 Brand | 666 | `<img src="/brand-icons/f5-icon-*.svg" />` | [F5 Brand](/icons/brand/) |
-| Lucide | ~1,600 | `<Icon name="lucide:rocket" />` | [Lucide](/icons/lucide/) |
-| Material Design | 7,000+ | `<Icon name="mdi:database" />` | [Iconify Packs](/icons/iconify-packs/) |
-| Carbon | ~1,500 | `<Icon name="carbon:cloud" />` | [Iconify Packs](/icons/iconify-packs/) |
-| Phosphor | ~1,200 | `<Icon name="ph:globe" />` | [Iconify Packs](/icons/iconify-packs/) |
-| Tabler | ~4,500 | `<Icon name="tabler:shield" />` | [Iconify Packs](/icons/iconify-packs/) |
+| Lucide | ~1,600 | `<img>` via Iconify API | [Lucide](/icons/lucide/) |
+| Material Design | 7,000+ | `<img>` via Iconify API | [Iconify Packs](/icons/iconify-packs/) |
+| Carbon | ~1,500 | `<img>` via Iconify API | [Iconify Packs](/icons/iconify-packs/) |
+| Phosphor | ~1,200 | `<img>` via Iconify API | [Iconify Packs](/icons/iconify-packs/) |
+| Tabler | ~4,500 | `<img>` via Iconify API | [Iconify Packs](/icons/iconify-packs/) |
 | HashiCorp Flight | 671 | `<img>` via CDN | [HashiCorp Flight](/icons/hashicorp-flight/) |
 
 ## Rendering Methods
 
 There are three ways to render icons, each with different dark mode behavior.
 
-### 1. `<Icon>` Component (Starlight + Iconify)
+### 1. `<Icon>` Component (Starlight Built-in)
 
-Used for Starlight built-in icons and all Iconify packs (Lucide, MDI, Carbon, Phosphor, Tabler).
+Used for Starlight's ~200 built-in icons. These are the only icons supported by the `<Icon>` component.
 
 ```mdx
 import { Icon } from '@astrojs/starlight/components';
 
 <Icon name="star" />
-<Icon name="lucide:rocket" size="2rem" />
-<Icon name="mdi:database" color="var(--sl-color-accent)" />
+<Icon name="rocket" size="2rem" />
+<Icon name="heart" color="var(--sl-color-accent)" />
 ```
 
 Icons render as inline SVGs using `currentColor` — they automatically adapt to light and dark mode with no special handling needed.
@@ -48,7 +48,31 @@ Icons render as inline SVGs using `currentColor` — they automatically adapt to
   <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="heart" size="1.5rem" /></div><div class="icon-card-label">heart</div></div>
 </div>
 
-### 2. `<img>` with Local SVG Path (F5 Brand)
+### 2. `<img>` with Iconify API (Lucide, MDI, Carbon, Phosphor, Tabler)
+
+Used for all Iconify icon packs. Reference icons via the Iconify API URL pattern:
+
+```mdx
+<img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" />
+<img src="https://api.iconify.design/mdi/database.svg" alt="database" width="24" height="24" />
+```
+
+Wrap in `.icon-card-image` for automatic dark mode inversion:
+
+```mdx
+<div class="icon-card-image" style="display:inline-flex;">
+  <img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" />
+</div>
+```
+
+<div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" /></div><div class="icon-card-label">lucide/rocket</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/mdi/database.svg" alt="database" width="24" height="24" /></div><div class="icon-card-label">mdi/database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/carbon/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">carbon/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/tabler/shield.svg" alt="shield" width="24" height="24" /></div><div class="icon-card-label">tabler/shield</div></div>
+</div>
+
+### 3. `<img>` with Local SVG Path (F5 Brand)
 
 Used for the 666 F5 brand icons stored in `docs/brand-icons/`.
 
@@ -58,7 +82,7 @@ Used for the 666 F5 brand icons stored in `docs/brand-icons/`.
 
 These monochrome SVGs get `filter: invert(1)` applied in dark mode via the `.icon-card-image` CSS class.
 
-### 3. `<img>` with CDN URL (HashiCorp Flight)
+### 4. `<img>` with CDN URL (HashiCorp Flight)
 
 Used for HashiCorp Flight icons loaded from jsDelivr CDN.
 
@@ -106,7 +130,7 @@ The theme CSS handles dark mode for `<img>` icons:
 | General UI (arrows, close, search) | Starlight Built-in | Zero config, always available |
 | F5 product diagrams | F5 Brand | Domain-specific networking/security art |
 | Modern stroke icons | Lucide | Clean, consistent 1,600+ icons |
-| Filled/outlined icons at scale | Material Design (mdi:) | Largest set with 7,000+ icons |
+| Filled/outlined icons at scale | Material Design (mdi) | Largest set with 7,000+ icons |
 | IBM design language | Carbon | Enterprise-grade icons |
 | Flexible weight options | Phosphor | Thin/light/regular/bold/fill/duotone |
 | Crisp line icons | Tabler | 4,500+ with consistent stroke |

--- a/docs/icons/lucide.mdx
+++ b/docs/icons/lucide.mdx
@@ -1,27 +1,29 @@
 ---
 title: Lucide Icons
-description: Curated reference for Lucide icons — 1,600+ modern stroke icons available via the Icon component.
+description: Curated reference for Lucide icons — 1,600+ modern stroke icons available via the Iconify API.
 sidebar:
   label: Lucide
   order: 4
 ---
 
-import { Icon } from '@astrojs/starlight/components';
-
 [Lucide](https://lucide.dev/) provides ~1,600 modern, consistent stroke icons. The `@iconify-json/lucide` and `@lucide/astro` packages are installed in the docs-builder container.
 
 ## Usage
 
-### Via Iconify (Recommended)
+### Via Iconify API (Recommended)
 
-Use the `lucide:` prefix with the Starlight `<Icon>` component:
+Use `<img>` tags referencing the Iconify API for any Lucide icon:
 
 ```mdx
-import { Icon } from '@astrojs/starlight/components';
+<img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" />
+```
 
-<Icon name="lucide:rocket" />
-<Icon name="lucide:shield" size="2rem" />
-<Icon name="lucide:cloud" color="var(--sl-color-accent)" />
+Wrap in `.icon-card-image` for automatic dark mode inversion:
+
+```mdx
+<div class="icon-card-image" style="display:inline-flex;">
+  <img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" />
+</div>
 ```
 
 ### Via Lucide Astro (Alternative)
@@ -35,99 +37,99 @@ import { Rocket, Shield, Cloud } from 'lucide-astro';
 <Shield size={24} strokeWidth={1.5} />
 ```
 
-Both methods render inline SVGs using `currentColor` — icons automatically adapt to light and dark mode.
+Lucide Astro components render inline SVGs using `currentColor` — they automatically adapt to light and dark mode.
 
 ## Navigation
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:arrow-up" size="1.5rem" /></div><div class="icon-card-label">lucide:arrow-up</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:arrow-down" size="1.5rem" /></div><div class="icon-card-label">lucide:arrow-down</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:arrow-left" size="1.5rem" /></div><div class="icon-card-label">lucide:arrow-left</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:arrow-right" size="1.5rem" /></div><div class="icon-card-label">lucide:arrow-right</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:chevron-up" size="1.5rem" /></div><div class="icon-card-label">lucide:chevron-up</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:chevron-down" size="1.5rem" /></div><div class="icon-card-label">lucide:chevron-down</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:chevron-left" size="1.5rem" /></div><div class="icon-card-label">lucide:chevron-left</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:chevron-right" size="1.5rem" /></div><div class="icon-card-label">lucide:chevron-right</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:external-link" size="1.5rem" /></div><div class="icon-card-label">lucide:external-link</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:home" size="1.5rem" /></div><div class="icon-card-label">lucide:home</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/arrow-up.svg" alt="arrow-up" width="24" height="24" /></div><div class="icon-card-label">lucide/arrow-up</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/arrow-down.svg" alt="arrow-down" width="24" height="24" /></div><div class="icon-card-label">lucide/arrow-down</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/arrow-left.svg" alt="arrow-left" width="24" height="24" /></div><div class="icon-card-label">lucide/arrow-left</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/arrow-right.svg" alt="arrow-right" width="24" height="24" /></div><div class="icon-card-label">lucide/arrow-right</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/chevron-up.svg" alt="chevron-up" width="24" height="24" /></div><div class="icon-card-label">lucide/chevron-up</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/chevron-down.svg" alt="chevron-down" width="24" height="24" /></div><div class="icon-card-label">lucide/chevron-down</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/chevron-left.svg" alt="chevron-left" width="24" height="24" /></div><div class="icon-card-label">lucide/chevron-left</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/chevron-right.svg" alt="chevron-right" width="24" height="24" /></div><div class="icon-card-label">lucide/chevron-right</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/external-link.svg" alt="external-link" width="24" height="24" /></div><div class="icon-card-label">lucide/external-link</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/home.svg" alt="home" width="24" height="24" /></div><div class="icon-card-label">lucide/home</div></div>
 </div>
 
 ## Actions
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:search" size="1.5rem" /></div><div class="icon-card-label">lucide:search</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:plus" size="1.5rem" /></div><div class="icon-card-label">lucide:plus</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:minus" size="1.5rem" /></div><div class="icon-card-label">lucide:minus</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:x" size="1.5rem" /></div><div class="icon-card-label">lucide:x</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:check" size="1.5rem" /></div><div class="icon-card-label">lucide:check</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:copy" size="1.5rem" /></div><div class="icon-card-label">lucide:copy</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:download" size="1.5rem" /></div><div class="icon-card-label">lucide:download</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:upload" size="1.5rem" /></div><div class="icon-card-label">lucide:upload</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:trash-2" size="1.5rem" /></div><div class="icon-card-label">lucide:trash-2</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:edit" size="1.5rem" /></div><div class="icon-card-label">lucide:edit</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/search.svg" alt="search" width="24" height="24" /></div><div class="icon-card-label">lucide/search</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/plus.svg" alt="plus" width="24" height="24" /></div><div class="icon-card-label">lucide/plus</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/minus.svg" alt="minus" width="24" height="24" /></div><div class="icon-card-label">lucide/minus</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/x.svg" alt="x" width="24" height="24" /></div><div class="icon-card-label">lucide/x</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/check.svg" alt="check" width="24" height="24" /></div><div class="icon-card-label">lucide/check</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/copy.svg" alt="copy" width="24" height="24" /></div><div class="icon-card-label">lucide/copy</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/download.svg" alt="download" width="24" height="24" /></div><div class="icon-card-label">lucide/download</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/upload.svg" alt="upload" width="24" height="24" /></div><div class="icon-card-label">lucide/upload</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/trash-2.svg" alt="trash-2" width="24" height="24" /></div><div class="icon-card-label">lucide/trash-2</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/edit.svg" alt="edit" width="24" height="24" /></div><div class="icon-card-label">lucide/edit</div></div>
 </div>
 
 ## Objects
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:file" size="1.5rem" /></div><div class="icon-card-label">lucide:file</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:folder" size="1.5rem" /></div><div class="icon-card-label">lucide:folder</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:image" size="1.5rem" /></div><div class="icon-card-label">lucide:image</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:settings" size="1.5rem" /></div><div class="icon-card-label">lucide:settings</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:calendar" size="1.5rem" /></div><div class="icon-card-label">lucide:calendar</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:clock" size="1.5rem" /></div><div class="icon-card-label">lucide:clock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:bookmark" size="1.5rem" /></div><div class="icon-card-label">lucide:bookmark</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:star" size="1.5rem" /></div><div class="icon-card-label">lucide:star</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:heart" size="1.5rem" /></div><div class="icon-card-label">lucide:heart</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:rocket" size="1.5rem" /></div><div class="icon-card-label">lucide:rocket</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/file.svg" alt="file" width="24" height="24" /></div><div class="icon-card-label">lucide/file</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/folder.svg" alt="folder" width="24" height="24" /></div><div class="icon-card-label">lucide/folder</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/image.svg" alt="image" width="24" height="24" /></div><div class="icon-card-label">lucide/image</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/settings.svg" alt="settings" width="24" height="24" /></div><div class="icon-card-label">lucide/settings</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/calendar.svg" alt="calendar" width="24" height="24" /></div><div class="icon-card-label">lucide/calendar</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/clock.svg" alt="clock" width="24" height="24" /></div><div class="icon-card-label">lucide/clock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/bookmark.svg" alt="bookmark" width="24" height="24" /></div><div class="icon-card-label">lucide/bookmark</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/star.svg" alt="star" width="24" height="24" /></div><div class="icon-card-label">lucide/star</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/heart.svg" alt="heart" width="24" height="24" /></div><div class="icon-card-label">lucide/heart</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/rocket.svg" alt="rocket" width="24" height="24" /></div><div class="icon-card-label">lucide/rocket</div></div>
 </div>
 
 ## Communication
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:mail" size="1.5rem" /></div><div class="icon-card-label">lucide:mail</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:message-circle" size="1.5rem" /></div><div class="icon-card-label">lucide:message-circle</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:phone" size="1.5rem" /></div><div class="icon-card-label">lucide:phone</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:send" size="1.5rem" /></div><div class="icon-card-label">lucide:send</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:bell" size="1.5rem" /></div><div class="icon-card-label">lucide:bell</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/mail.svg" alt="mail" width="24" height="24" /></div><div class="icon-card-label">lucide/mail</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/message-circle.svg" alt="message-circle" width="24" height="24" /></div><div class="icon-card-label">lucide/message-circle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/phone.svg" alt="phone" width="24" height="24" /></div><div class="icon-card-label">lucide/phone</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/send.svg" alt="send" width="24" height="24" /></div><div class="icon-card-label">lucide/send</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/bell.svg" alt="bell" width="24" height="24" /></div><div class="icon-card-label">lucide/bell</div></div>
 </div>
 
 ## Security &amp; Status
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:shield" size="1.5rem" /></div><div class="icon-card-label">lucide:shield</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:lock" size="1.5rem" /></div><div class="icon-card-label">lucide:lock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:unlock" size="1.5rem" /></div><div class="icon-card-label">lucide:unlock</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:key" size="1.5rem" /></div><div class="icon-card-label">lucide:key</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:eye" size="1.5rem" /></div><div class="icon-card-label">lucide:eye</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:alert-triangle" size="1.5rem" /></div><div class="icon-card-label">lucide:alert-triangle</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:info" size="1.5rem" /></div><div class="icon-card-label">lucide:info</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:circle-check" size="1.5rem" /></div><div class="icon-card-label">lucide:circle-check</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:circle-x" size="1.5rem" /></div><div class="icon-card-label">lucide:circle-x</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:loader" size="1.5rem" /></div><div class="icon-card-label">lucide:loader</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/shield.svg" alt="shield" width="24" height="24" /></div><div class="icon-card-label">lucide/shield</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/lock.svg" alt="lock" width="24" height="24" /></div><div class="icon-card-label">lucide/lock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/unlock.svg" alt="unlock" width="24" height="24" /></div><div class="icon-card-label">lucide/unlock</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/key.svg" alt="key" width="24" height="24" /></div><div class="icon-card-label">lucide/key</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/eye.svg" alt="eye" width="24" height="24" /></div><div class="icon-card-label">lucide/eye</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/alert-triangle.svg" alt="alert-triangle" width="24" height="24" /></div><div class="icon-card-label">lucide/alert-triangle</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/info.svg" alt="info" width="24" height="24" /></div><div class="icon-card-label">lucide/info</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/circle-check.svg" alt="circle-check" width="24" height="24" /></div><div class="icon-card-label">lucide/circle-check</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/circle-x.svg" alt="circle-x" width="24" height="24" /></div><div class="icon-card-label">lucide/circle-x</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/loader.svg" alt="loader" width="24" height="24" /></div><div class="icon-card-label">lucide/loader</div></div>
 </div>
 
 ## Infrastructure
 
 <div class="not-content icon-grid" style="grid-template-columns: repeat(auto-fill, minmax(8rem, 1fr));">
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:cloud" size="1.5rem" /></div><div class="icon-card-label">lucide:cloud</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:server" size="1.5rem" /></div><div class="icon-card-label">lucide:server</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:database" size="1.5rem" /></div><div class="icon-card-label">lucide:database</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:globe" size="1.5rem" /></div><div class="icon-card-label">lucide:globe</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:network" size="1.5rem" /></div><div class="icon-card-label">lucide:network</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:wifi" size="1.5rem" /></div><div class="icon-card-label">lucide:wifi</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:hard-drive" size="1.5rem" /></div><div class="icon-card-label">lucide:hard-drive</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:cpu" size="1.5rem" /></div><div class="icon-card-label">lucide:cpu</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:terminal" size="1.5rem" /></div><div class="icon-card-label">lucide:terminal</div></div>
-  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><Icon name="lucide:code" size="1.5rem" /></div><div class="icon-card-label">lucide:code</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/cloud.svg" alt="cloud" width="24" height="24" /></div><div class="icon-card-label">lucide/cloud</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/server.svg" alt="server" width="24" height="24" /></div><div class="icon-card-label">lucide/server</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/database.svg" alt="database" width="24" height="24" /></div><div class="icon-card-label">lucide/database</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/globe.svg" alt="globe" width="24" height="24" /></div><div class="icon-card-label">lucide/globe</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/network.svg" alt="network" width="24" height="24" /></div><div class="icon-card-label">lucide/network</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/wifi.svg" alt="wifi" width="24" height="24" /></div><div class="icon-card-label">lucide/wifi</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/hard-drive.svg" alt="hard-drive" width="24" height="24" /></div><div class="icon-card-label">lucide/hard-drive</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/cpu.svg" alt="cpu" width="24" height="24" /></div><div class="icon-card-label">lucide/cpu</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/terminal.svg" alt="terminal" width="24" height="24" /></div><div class="icon-card-label">lucide/terminal</div></div>
+  <div class="icon-card"><div class="icon-card-image" style="display:flex;align-items:center;justify-content:center;padding:0.75rem;"><img src="https://api.iconify.design/lucide/code.svg" alt="code" width="24" height="24" /></div><div class="icon-card-label">lucide/code</div></div>
 </div>
 
 ## Browse All Icons
 
 For the complete list of ~1,600 Lucide icons, visit [lucide.dev/icons](https://lucide.dev/icons/).
 
-Use any icon name from the Lucide site with the `lucide:` prefix:
+Use the Iconify API URL pattern to reference any icon:
 
-```mdx
-<Icon name="lucide:icon-name-here" />
+```
+https://api.iconify.design/lucide/{icon-name}.svg
 ```


### PR DESCRIPTION
## Summary

- Replace broken `<Icon name="lucide:*" />` calls with `<img>` tags referencing the Iconify API CDN (`https://api.iconify.design/{prefix}/{name}.svg`)
- Update `docs/icons/index.mdx` to document the correct rendering method for Iconify packs and add a new "Iconify API" section
- Fix applies to all Iconify icon packs: Lucide, Material Design, Carbon, Phosphor, and Tabler

**Root cause**: The Starlight `<Icon>` component only supports ~200 built-in icons. Using `<Icon name="lucide:rocket" />` generated empty SVGs (correct `viewBox` but no `<path>` data). The `starlight-plugin-icons` plugin extends sidebar/card/file-tree icons but not the `<Icon>` component for inline MDX content.

## Test plan

- [ ] Verify Lucide icons page shows visible icons in all 6 category sections
- [ ] Verify Iconify Packs page shows visible icons for MDI, Carbon, Phosphor, and Tabler sections
- [ ] Verify Icons overview page shows Iconify API sample icons in the new rendering method section
- [ ] Toggle dark/light mode — confirm `.icon-card-image` CSS applies `filter: invert(1)` to Iconify API icons in dark mode
- [ ] Verify Starlight built-in icons on index.mdx still render correctly via `<Icon>` component

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)