### PR TITLE
feat: unified Icon component with scoped icon names

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -1,0 +1,96 @@
+---
+import StarlightIcon from '@astrojs/starlight/user-components/Icon.astro';
+
+interface Props {
+  name: string;
+  label?: string;
+  color?: string;
+  size?: string;
+  class?: string;
+}
+
+const { name, label, color, size, class: className } = Astro.props;
+const isScoped = name.includes(':');
+
+let svgBody = '';
+let viewBox = '0 0 24 24';
+
+if (isScoped) {
+  const colonIndex = name.indexOf(':');
+  const prefix = name.slice(0, colonIndex);
+  const iconName = name.slice(colonIndex + 1);
+
+  let iconData: any;
+
+  switch (prefix) {
+    case 'lucide':
+      iconData = (await import('@iconify-json/lucide/icons.json')).default;
+      break;
+    case 'carbon':
+      iconData = (await import('@iconify-json/carbon/icons.json')).default;
+      break;
+    case 'mdi':
+      iconData = (await import('@iconify-json/mdi/icons.json')).default;
+      break;
+    case 'phosphor':
+      iconData = (await import('@iconify-json/ph/icons.json')).default;
+      break;
+    case 'tabler':
+      iconData = (await import('@iconify-json/tabler/icons.json')).default;
+      break;
+    case 'f5-brand':
+      iconData = (await import('@robinmordasiewicz/icons-f5-brand/icons.json')).default;
+      break;
+    case 'hashicorp-flight':
+      iconData = (await import('@robinmordasiewicz/icons-hashicorp-flight/icons.json')).default;
+      break;
+    default:
+      throw new Error(
+        `Unknown icon prefix "${prefix}". Available: lucide, carbon, mdi, phosphor, tabler, f5-brand, hashicorp-flight`
+      );
+  }
+
+  const icon = iconData.icons?.[iconName];
+  if (!icon) {
+    throw new Error(`Icon "${iconName}" not found in "${prefix}" icon set.`);
+  }
+
+  svgBody = icon.body;
+  const w = icon.width ?? iconData.width ?? 24;
+  const h = icon.height ?? iconData.height ?? 24;
+  viewBox = `0 0 ${w} ${h}`;
+}
+
+const a11yAttrs = label
+  ? { 'aria-label': label }
+  : { 'aria-hidden': 'true' };
+
+const styleParts: string[] = [];
+if (color) styleParts.push(`--sl-icon-color: ${color}`);
+if (size) styleParts.push(`--sl-icon-size: ${size}`);
+const inlineStyle = styleParts.length ? styleParts.join('; ') : undefined;
+---
+
+{isScoped ? (
+  <><svg
+    {...a11yAttrs}
+    class={className}
+    width="16"
+    height="16"
+    fill="currentColor"
+    viewBox={viewBox}
+    style={inlineStyle}
+    set:html={svgBody}
+  /></>
+) : (
+  <StarlightIcon name={name as any} label={label} color={color} size={size} class={className} />
+)}
+
+<style>
+  svg {
+    color: var(--sl-icon-color);
+    font-size: var(--sl-icon-size, 1em);
+    width: 1em;
+    height: 1em;
+  }
+</style>

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "./assets/github-avatar.png": "./assets/github-avatar.png",
     "./config": "./config.ts",
     "./route-middleware": "./route-middleware.ts",
-    "./src/plugins/remark-mermaid.mjs": "./src/plugins/remark-mermaid.mjs"
+    "./src/plugins/remark-mermaid.mjs": "./src/plugins/remark-mermaid.mjs",
+    "./components/Icon.astro": "./components/Icon.astro"
   },
   "files": [
     "index.ts",
@@ -60,7 +61,23 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "peerDependencies": {
-    "@astrojs/starlight": ">=0.34.0"
+    "@astrojs/starlight": ">=0.34.0",
+    "@iconify-json/lucide": "*",
+    "@iconify-json/carbon": "*",
+    "@iconify-json/mdi": "*",
+    "@iconify-json/ph": "*",
+    "@iconify-json/tabler": "*",
+    "@robinmordasiewicz/icons-f5-brand": "*",
+    "@robinmordasiewicz/icons-hashicorp-flight": "*"
+  },
+  "peerDependenciesMeta": {
+    "@iconify-json/lucide": { "optional": true },
+    "@iconify-json/carbon": { "optional": true },
+    "@iconify-json/mdi": { "optional": true },
+    "@iconify-json/ph": { "optional": true },
+    "@iconify-json/tabler": { "optional": true },
+    "@robinmordasiewicz/icons-f5-brand": { "optional": true },
+    "@robinmordasiewicz/icons-hashicorp-flight": { "optional": true }
   },
   "dependencies": {
     "@astrojs/react": "^4.0.0",


### PR DESCRIPTION
## Summary
- Add unified `<Icon>` component supporting scoped icon names (`lucide:star`, `f5-brand:f5`, etc.)
- Unscoped names delegate to Starlight's built-in Icon component
- Icon packages declared as optional peer dependencies (satisfied by docs-builder)

## Test plan
- [ ] Verify scoped icons render correctly with each prefix (lucide, carbon, mdi, phosphor, tabler, f5-brand, hashicorp-flight)
- [ ] Verify unscoped names delegate to Starlight built-in icons
- [ ] Verify `label`, `color`, `size`, and `class` props work
- [ ] Verify error messages for invalid prefix and invalid icon name
- [ ] Verify accessibility attributes (aria-label when label provided, aria-hidden otherwise)

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)