### PR TITLE
docs: add icons reference page for unified Icon component

### DIFF
--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -322,13 +322,7 @@ The image below tests the `starlight-image-zoom` plugin. Click to zoom.
       - 03-astro-config.mdx
       - 04-logo.mdx
       - 05-colors.mdx
-      - icons/
-        - index.mdx
-        - starlight.mdx
-        - brand.mdx
-        - lucide.mdx
-        - iconify-packs.mdx
-        - hashicorp-flight.mdx
+      - icons.mdx
       - 07-typography.mdx
       - 08-code-blocks.mdx
       - **09-components.mdx** This page
@@ -349,7 +343,7 @@ Starlight provides over 200 built-in icons via the `<Icon>` component:
 
 <Icon name="star" size="1.5rem" /> <Icon name="rocket" size="1.5rem" /> <Icon name="heart" size="1.5rem" /> <Icon name="setting" size="1.5rem" /> <Icon name="pencil" size="1.5rem" /> <Icon name="document" size="1.5rem" /> <Icon name="open-book" size="1.5rem" /> <Icon name="laptop" size="1.5rem" />
 
-See the [Icons](/icons/) page for the complete reference with every icon name, props, seti file icons, and community icon packs.
+The theme also provides a unified Icon component supporting scoped names for additional icon sets (Lucide, Carbon, MDI, Phosphor, Tabler, F5 Brand, HashiCorp Flight). See the [Icons](/icons/) page for the full reference.
 
 ## Theme Checks
 

--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -1,0 +1,134 @@
+---
+title: Icons
+description: Unified Icon component with scoped names for Starlight built-in, Lucide, Carbon, MDI, Phosphor, Tabler, F5 Brand, and HashiCorp Flight icon sets.
+sidebar:
+  order: 13
+---
+
+import Icon from 'f5xc-docs-theme/components/Icon.astro';
+
+## Usage
+
+Import the unified Icon component from the theme package:
+
+```mdx
+import Icon from 'f5xc-docs-theme/components/Icon.astro';
+
+<Icon name="star" />                        {/* Starlight built-in */}
+<Icon name="lucide:rocket" size="2rem" />   {/* Lucide */}
+<Icon name="f5-brand:f5" size="2rem" />     {/* F5 Brand */}
+```
+
+Unscoped names (without a `:`) use Starlight's built-in icons. Scoped names use the prefix to select an icon set.
+
+## Starlight Built-in
+
+<Icon name="star" size="1.5rem" /> <Icon name="rocket" size="1.5rem" /> <Icon name="heart" size="1.5rem" /> <Icon name="setting" size="1.5rem" /> <Icon name="pencil" size="1.5rem" /> <Icon name="document" size="1.5rem" /> <Icon name="open-book" size="1.5rem" /> <Icon name="laptop" size="1.5rem" />
+
+```mdx
+<Icon name="star" size="1.5rem" />
+<Icon name="rocket" size="1.5rem" />
+<Icon name="heart" size="1.5rem" />
+```
+
+## Lucide
+
+<Icon name="lucide:arrow-right" size="1.5rem" /> <Icon name="lucide:check" size="1.5rem" /> <Icon name="lucide:circle-alert" size="1.5rem" /> <Icon name="lucide:cloud" size="1.5rem" /> <Icon name="lucide:code" size="1.5rem" /> <Icon name="lucide:database" size="1.5rem" /> <Icon name="lucide:globe" size="1.5rem" /> <Icon name="lucide:shield" size="1.5rem" />
+
+```mdx
+<Icon name="lucide:arrow-right" size="1.5rem" />
+<Icon name="lucide:shield" size="1.5rem" />
+```
+
+## Carbon
+
+<Icon name="carbon:dashboard" size="1.5rem" /> <Icon name="carbon:analytics" size="1.5rem" /> <Icon name="carbon:cloud" size="1.5rem" /> <Icon name="carbon:security" size="1.5rem" /> <Icon name="carbon:network--2" size="1.5rem" /> <Icon name="carbon:api" size="1.5rem" /> <Icon name="carbon:document" size="1.5rem" /> <Icon name="carbon:settings" size="1.5rem" />
+
+```mdx
+<Icon name="carbon:dashboard" size="1.5rem" />
+<Icon name="carbon:analytics" size="1.5rem" />
+```
+
+## Material Design Icons
+
+<Icon name="mdi:account" size="1.5rem" /> <Icon name="mdi:home" size="1.5rem" /> <Icon name="mdi:bell" size="1.5rem" /> <Icon name="mdi:cog" size="1.5rem" /> <Icon name="mdi:magnify" size="1.5rem" /> <Icon name="mdi:shield-check" size="1.5rem" /> <Icon name="mdi:cloud-outline" size="1.5rem" /> <Icon name="mdi:lock" size="1.5rem" />
+
+```mdx
+<Icon name="mdi:account" size="1.5rem" />
+<Icon name="mdi:shield-check" size="1.5rem" />
+```
+
+## Tabler
+
+<Icon name="tabler:settings" size="1.5rem" /> <Icon name="tabler:user" size="1.5rem" /> <Icon name="tabler:home" size="1.5rem" /> <Icon name="tabler:bell" size="1.5rem" /> <Icon name="tabler:search" size="1.5rem" /> <Icon name="tabler:shield-lock" size="1.5rem" /> <Icon name="tabler:database" size="1.5rem" /> <Icon name="tabler:cloud" size="1.5rem" />
+
+```mdx
+<Icon name="tabler:settings" size="1.5rem" />
+<Icon name="tabler:shield-lock" size="1.5rem" />
+```
+
+## Phosphor
+
+<Icon name="phosphor:lightning" size="1.5rem" /> <Icon name="phosphor:globe" size="1.5rem" /> <Icon name="phosphor:shield-check" size="1.5rem" /> <Icon name="phosphor:gear" size="1.5rem" /> <Icon name="phosphor:cloud" size="1.5rem" /> <Icon name="phosphor:lock" size="1.5rem" /> <Icon name="phosphor:database" size="1.5rem" /> <Icon name="phosphor:code" size="1.5rem" />
+
+```mdx
+<Icon name="phosphor:lightning" size="1.5rem" />
+<Icon name="phosphor:shield-check" size="1.5rem" />
+```
+
+## F5 Brand
+
+<Icon name="f5-brand:f5" size="1.5rem" /> <Icon name="f5-brand:distributed-cloud" size="1.5rem" /> <Icon name="f5-brand:nginx" size="1.5rem" />
+
+```mdx
+<Icon name="f5-brand:f5" size="1.5rem" />
+<Icon name="f5-brand:distributed-cloud" size="1.5rem" />
+```
+
+## HashiCorp Flight
+
+<Icon name="hashicorp-flight:terraform" size="1.5rem" /> <Icon name="hashicorp-flight:vault" size="1.5rem" /> <Icon name="hashicorp-flight:consul" size="1.5rem" />
+
+```mdx
+<Icon name="hashicorp-flight:terraform" size="1.5rem" />
+<Icon name="hashicorp-flight:vault" size="1.5rem" />
+```
+
+## Props
+
+| Prop | Type | Default | Description |
+|------|------|---------|-------------|
+| `name` | `string` | (required) | Icon name — unscoped for Starlight built-in, or `prefix:name` for icon sets |
+| `label` | `string` | — | Accessibility label. Sets `aria-label` when provided, `aria-hidden` otherwise |
+| `color` | `string` | — | CSS color value |
+| `size` | `string` | `1em` | CSS size value |
+| `class` | `string` | — | Additional CSS classes |
+
+## Styling
+
+<Icon name="lucide:star" size="1rem" /> Default size (1rem)
+
+<Icon name="lucide:star" size="2rem" /> Larger (2rem)
+
+<Icon name="lucide:star" size="3rem" color="var(--sl-color-accent)" /> Accent color (3rem)
+
+<Icon name="lucide:star" size="2rem" label="Favorite" /> With accessibility label
+
+```mdx
+<Icon name="lucide:star" size="2rem" />
+<Icon name="lucide:star" size="3rem" color="var(--sl-color-accent)" />
+<Icon name="lucide:star" size="2rem" label="Favorite" />
+```
+
+## Available Prefixes
+
+| Prefix | Package | Icons |
+|--------|---------|-------|
+| *(none)* | Starlight built-in | 200+ |
+| `lucide` | `@iconify-json/lucide` | 1,700+ |
+| `carbon` | `@iconify-json/carbon` | 2,100+ |
+| `mdi` | `@iconify-json/mdi` | 7,600+ |
+| `phosphor` | `@iconify-json/ph` | 9,100+ |
+| `tabler` | `@iconify-json/tabler` | 5,400+ |
+| `f5-brand` | `@robinmordasiewicz/icons-f5-brand` | 665 |
+| `hashicorp-flight` | `@robinmordasiewicz/icons-hashicorp-flight` | 300+ |


### PR DESCRIPTION
## Summary
- Add `docs/icons.mdx` with examples of all 7 scoped icon prefixes plus Starlight built-in icons
- Update `docs/components.mdx` to reference the new icons page and fix the file tree

## Test plan
- [ ] All scoped icon prefixes render correctly on the icons page
- [ ] Starlight built-in icons still render in both pages
- [ ] Props table and styling examples display correctly
- [ ] File tree in components.mdx matches current docs structure

Closes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)