### PR TITLE
fix: use correct Starlight Icon import path

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -1,5 +1,5 @@
 ---
-import StarlightIcon from '@astrojs/starlight/user-components/Icon.astro';
+import { Icon as StarlightIcon } from '@astrojs/starlight/components';
 
 interface Props {
   name: string;


### PR DESCRIPTION
## Summary
- Fix import from `@astrojs/starlight/user-components/Icon.astro` (not in exports map) to `@astrojs/starlight/components` (public API)

## Test plan
- [ ] Build succeeds in docs-builder container
- [ ] Unscoped icon names still delegate to Starlight's built-in Icon

Closes #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)