### PR TITLE
fix: replace invalid carbon icon name in docs

### DIFF
--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -42,7 +42,7 @@ Unscoped names (without a `:`) use Starlight's built-in icons. Scoped names use 
 
 ## Carbon
 
-<Icon name="carbon:dashboard" size="1.5rem" /> <Icon name="carbon:analytics" size="1.5rem" /> <Icon name="carbon:cloud" size="1.5rem" /> <Icon name="carbon:security" size="1.5rem" /> <Icon name="carbon:network--2" size="1.5rem" /> <Icon name="carbon:api" size="1.5rem" /> <Icon name="carbon:document" size="1.5rem" /> <Icon name="carbon:settings" size="1.5rem" />
+<Icon name="carbon:dashboard" size="1.5rem" /> <Icon name="carbon:analytics" size="1.5rem" /> <Icon name="carbon:cloud" size="1.5rem" /> <Icon name="carbon:security" size="1.5rem" /> <Icon name="carbon:data-base" size="1.5rem" /> <Icon name="carbon:api" size="1.5rem" /> <Icon name="carbon:document" size="1.5rem" /> <Icon name="carbon:settings" size="1.5rem" />
 
 ```mdx
 <Icon name="carbon:dashboard" size="1.5rem" />


### PR DESCRIPTION
## Summary
- Replace `carbon:network--2` (does not exist in carbon icon set) with `carbon:data-base`

## Test plan
- [ ] Icons page builds without errors
- [ ] All carbon icons render correctly

Closes #103

🤖 Generated with [Claude Code](https://claude.com/claude-code)