### PR TITLE
fix: correct F5 brand icon names in icons documentation

### DIFF
--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -16,7 +16,7 @@ import Icon from 'f5xc-docs-theme/components/Icon.astro';
 
 <Icon name="star" />                        {/* Starlight built-in */}
 <Icon name="lucide:rocket" size="2rem" />   {/* Lucide */}
-<Icon name="f5-brand:f5" size="2rem" />     {/* F5 Brand */}
+<Icon name="f5-brand:service-f5" size="2rem" />     {/* F5 Brand */}
 ```
 
 Unscoped names (without a `:`) use Starlight's built-in icons. Scoped names use the prefix to select an icon set.
@@ -78,11 +78,11 @@ Unscoped names (without a `:`) use Starlight's built-in icons. Scoped names use 
 
 ## F5 Brand
 
-<Icon name="f5-brand:f5" size="1.5rem" /> <Icon name="f5-brand:distributed-cloud" size="1.5rem" /> <Icon name="f5-brand:nginx" size="1.5rem" />
+<Icon name="f5-brand:service-f5" size="1.5rem" /> <Icon name="f5-brand:cloud-distributed" size="1.5rem" /> <Icon name="f5-brand:service-nginx" size="1.5rem" />
 
 ```mdx
-<Icon name="f5-brand:f5" size="1.5rem" />
-<Icon name="f5-brand:distributed-cloud" size="1.5rem" />
+<Icon name="f5-brand:service-f5" size="1.5rem" />
+<Icon name="f5-brand:cloud-distributed" size="1.5rem" />
 ```
 
 ## HashiCorp Flight


### PR DESCRIPTION
## Summary
- Fix incorrect F5 brand icon names in `docs/icons.mdx` that cause build failures
- `f5-brand:f5` → `f5-brand:service-f5`
- `f5-brand:distributed-cloud` → `f5-brand:cloud-distributed`
- `f5-brand:nginx` → `f5-brand:service-nginx`

## Test plan
- [ ] GitHub Pages deploy succeeds without icon not found errors
- [ ] F5 Brand icons render correctly on the icons documentation page

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)