### PR TITLE
Add Icons sidebar link redirecting to docs-icons site

### DIFF
--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -1,0 +1,12 @@
+---
+title: Icons
+sidebar:
+  order: 99
+head:
+  - tag: meta
+    attrs:
+      http-equiv: refresh
+      content: "0;url=https://f5xc-salesdemos.github.io/docs-icons/"
+---
+
+Redirecting to [Icons documentation](https://f5xc-salesdemos.github.io/docs-icons/)…


### PR DESCRIPTION
## Summary
- Add `docs/icons.mdx` redirect page that appears at the bottom of the sidebar (order 99)
- Uses `<meta http-equiv="refresh">` to immediately redirect to https://f5xc-salesdemos.github.io/docs-icons/ in the same tab
- Content-level change only — no theme infrastructure modifications

Closes #119

## Test plan
- [ ] Sidebar shows "Icons" at the bottom of the navigation
- [ ] Clicking the link redirects to the docs-icons site in the same tab
- [ ] `npm run build` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)