### PR TITLE
fix: remove Home mega menu item from default navigation

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -59,10 +59,6 @@ export interface F5xcDocsConfigOptions {
 
 const defaultMegaMenuItems: MegaMenuItem[] = [
   {
-    label: 'Home',
-    href: 'https://f5xc-salesdemos.github.io/docs/',
-  },
-  {
     label: 'Security',
     content: {
       layout: 'grid',


### PR DESCRIPTION
## Summary

- Remove the redundant "Home" mega menu item from `defaultMegaMenuItems` in `config.ts`
- The logo/site title already links to the home page, making the explicit Home entry unnecessary

## Related Issue

Closes #122

## Type of Change

- [x] Bug fix (non-breaking change which fixes an issue)

## Testing

- [x] Verified remaining mega menu items (Security, Networking, Platform, Resources) are unaffected

## Test plan

- [ ] Verify mega menu renders correctly without the Home item
- [ ] Verify logo/site title still links to home page

🤖 Generated with [Claude Code](https://claude.com/claude-code)