### PR TITLE
feat: add icon prop support to LinkCard component

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -1,0 +1,92 @@
+---
+import Icon from './Icon.astro';
+import type { HTMLAttributes } from 'astro/types';
+
+interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
+	title: string;
+	description?: string;
+	icon?: string;
+}
+
+const { title, description, icon, ...attributes } = Astro.props;
+---
+
+<div class:list={['sl-link-card', { 'has-icon': !!icon }]}>
+	{icon && (
+		<span class="card-icon">
+			<Icon name={icon} size="1.5em" />
+		</span>
+	)}
+	<span class="sl-flex stack">
+		<a {...attributes}>
+			<span class="title" set:html={title} />
+		</a>
+		{description && <span class="description" set:html={description} />}
+	</span>
+	<Icon name="right-arrow" size="1.333em" class="icon rtl:flip" />
+</div>
+
+<style>
+	.sl-link-card {
+		display: grid;
+		grid-template-columns: 1fr auto;
+		gap: 0.5rem;
+		border: 1px solid var(--sl-color-gray-5);
+		border-radius: 0.5rem;
+		padding: 1rem;
+		box-shadow: var(--sl-shadow-sm);
+		position: relative;
+	}
+
+	.sl-link-card.has-icon {
+		grid-template-columns: auto 1fr auto;
+	}
+
+	a {
+		text-decoration: none;
+		line-height: var(--sl-line-height-headings);
+	}
+
+	/* a11y fix for https://github.com/withastro/starlight/issues/487 */
+	a::before {
+		content: '';
+		position: absolute;
+		inset: 0;
+	}
+
+	.stack {
+		flex-direction: column;
+		gap: 0.5rem;
+	}
+
+	.title {
+		color: var(--sl-color-white);
+		font-weight: 600;
+		font-size: var(--sl-text-lg);
+	}
+
+	.description {
+		color: var(--sl-color-gray-3);
+		line-height: 1.5;
+	}
+
+	.icon {
+		color: var(--sl-color-gray-3);
+	}
+
+	.card-icon {
+		color: var(--sl-color-white);
+		display: flex;
+		align-items: center;
+	}
+
+	/* Hover state */
+	.sl-link-card:hover {
+		background: var(--sl-color-gray-7, var(--sl-color-gray-6));
+		border-color: var(--sl-color-gray-2);
+	}
+
+	.sl-link-card:hover .icon {
+		color: var(--sl-color-white);
+	}
+</style>

--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -9,6 +9,7 @@ sidebar:
 ---
 
 import { Aside, Tabs, TabItem, Steps, Card, CardGrid, LinkCard, Badge, FileTree } from '@astrojs/starlight/components';
+import IconLinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 
 ## Asides
 
@@ -232,6 +233,39 @@ These two tab groups share `syncKey="pkg"`. Selecting a tab in one group should 
     title="Astro Documentation"
     description="Explore the Astro framework for content-driven websites."
     href="https://docs.astro.build"
+  />
+</CardGrid>
+
+### Link Cards with Icons
+
+The theme provides a custom `LinkCard` component that supports an optional `icon` prop. Import it from the theme package:
+
+```mdx
+import IconLinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+```
+
+<CardGrid>
+  <IconLinkCard
+    icon="lucide:shield-check"
+    title="Web App Firewall"
+    description="Firewall policies and configuration."
+    href="https://f5xc-salesdemos.github.io/waf/"
+  />
+  <IconLinkCard
+    icon="lucide:globe"
+    title="Multi-Cloud Networking"
+    description="Site connectivity across clouds."
+    href="https://f5xc-salesdemos.github.io/mcn/"
+  />
+</CardGrid>
+
+Without the `icon` prop it renders identically to the standard `LinkCard`:
+
+<CardGrid>
+  <IconLinkCard
+    title="No Icon Example"
+    description="This card behaves like a standard LinkCard."
+    href="https://starlight.astro.build"
   />
 </CardGrid>
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "./config": "./config.ts",
     "./route-middleware": "./route-middleware.ts",
     "./src/plugins/remark-mermaid.mjs": "./src/plugins/remark-mermaid.mjs",
-    "./components/Icon.astro": "./components/Icon.astro"
+    "./components/Icon.astro": "./components/Icon.astro",
+    "./components/LinkCard.astro": "./components/LinkCard.astro"
   },
   "files": [
     "index.ts",


### PR DESCRIPTION
## Summary

- Create a custom `LinkCard` component (`components/LinkCard.astro`) that supports an optional `icon` prop
- When `icon` is provided, it renders to the left of the title using a three-column grid layout (icon | text | arrow)
- When no `icon` is provided, it renders identically to Starlight's standard `LinkCard`
- Uses the existing `Icon.astro` component for all scoped icon resolution (lucide, carbon, mdi, f5-brand, etc.)
- Export the new component in `package.json`
- Add demo section in `docs/components.mdx`

## Related Issue

Closes #124

## Type of Change

- [x] New feature (non-breaking change which adds functionality)

## Usage

```mdx
import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';

<LinkCard
  icon="lucide:shield-check"
  title="WAF"
  description="Web application firewall configuration."
  href="https://f5xc-salesdemos.github.io/waf/"
/>
```

## Test plan

- [ ] Verify LinkCard renders correctly with an icon (e.g., `lucide:shield-check`)
- [ ] Verify LinkCard renders correctly without an icon (standard behavior)
- [ ] Verify all icon prefixes work (lucide, carbon, mdi, f5-brand, etc.)
- [ ] Verify hover states and accessibility match Starlight's LinkCard

🤖 Generated with [Claude Code](https://claude.com/claude-code)