### PR TITLE
docs: add icon pack examples for all supported icon sets

### DIFF
--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -241,8 +241,12 @@ These two tab groups share `syncKey="pkg"`. Selecting a tab in one group should 
 The theme provides a custom `LinkCard` component that supports an optional `icon` prop. Import it from the theme package:
 
 ```mdx
-import IconLinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 ```
+
+All seven icon packs are supported via the `prefix:name` syntax. See the [Icon Packages](https://f5xc-salesdemos.github.io/docs-icons/) documentation for the full catalog.
+
+#### Lucide (`lucide:`)
 
 <CardGrid>
   <IconLinkCard
@@ -258,6 +262,110 @@ import IconLinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
     href="https://f5xc-salesdemos.github.io/mcn/"
   />
 </CardGrid>
+
+#### Carbon (`carbon:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="carbon:security"
+    title="Security Services"
+    description="IBM Carbon security icon set."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="carbon:cloud"
+    title="Cloud Services"
+    description="IBM Carbon cloud icon set."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### Material Design Icons (`mdi:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="mdi:shield-lock"
+    title="Access Control"
+    description="Material Design shield lock icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="mdi:database"
+    title="Data Management"
+    description="Material Design database icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### Phosphor (`phosphor:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="phosphor:shield"
+    title="Threat Defense"
+    description="Phosphor shield icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="phosphor:globe"
+    title="Global Network"
+    description="Phosphor globe icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### Tabler (`tabler:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="tabler:cloud"
+    title="Cloud Platform"
+    description="Tabler cloud icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="tabler:rocket"
+    title="Deployment"
+    description="Tabler rocket icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### F5 Brand (`f5-brand:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="f5-brand:cloud-shield-checkmark"
+    title="Cloud Security"
+    description="F5 branded cloud shield icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="f5-brand:security-firewall"
+    title="Firewall"
+    description="F5 branded firewall icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### HashiCorp Flight (`hashicorp-flight:`)
+
+<CardGrid>
+  <IconLinkCard
+    icon="hashicorp-flight:terraform"
+    title="Terraform"
+    description="HashiCorp Terraform icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="hashicorp-flight:cloud"
+    title="Cloud Infrastructure"
+    description="HashiCorp cloud icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### Without Icon
 
 Without the `icon` prop it renders identically to the standard `LinkCard`:
 


### PR DESCRIPTION
## Summary

- Expand the LinkCard with Icons demo section to show examples from all 7 supported icon packs
- Each pack gets its own subsection with two representative example cards
- Links to the [Icon Packages](https://f5xc-salesdemos.github.io/docs-icons/) documentation for the full catalog

## Icon Packs Demonstrated

| Pack | Prefix | Example Icons |
|------|--------|---------------|
| Lucide | `lucide:` | `shield-check`, `globe` |
| Carbon | `carbon:` | `security`, `cloud` |
| Material Design | `mdi:` | `shield-lock`, `database` |
| Phosphor | `phosphor:` | `shield`, `globe` |
| Tabler | `tabler:` | `cloud`, `rocket` |
| F5 Brand | `f5-brand:` | `cloud-shield-checkmark`, `security-firewall` |
| HashiCorp Flight | `hashicorp-flight:` | `terraform`, `cloud` |

## Related Issue

Closes #127

## Type of Change

- [x] Documentation update

## Test plan

- [ ] Verify all icon packs render correctly in the LinkCard component
- [ ] Verify page builds successfully once docs-builder image is updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)