### PR TITLE
feat: register f5xc icon prefix and add conditional fill for palette icon sets

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -41,12 +41,15 @@ if (isScoped) {
     case 'f5-brand':
       iconData = (await import('@robinmordasiewicz/icons-f5-brand/icons.json')).default;
       break;
+    case 'f5xc':
+      iconData = (await import('@robinmordasiewicz/icons-f5xc/icons.json')).default;
+      break;
     case 'hashicorp-flight':
       iconData = (await import('@robinmordasiewicz/icons-hashicorp-flight/icons.json')).default;
       break;
     default:
       throw new Error(
-        `Unknown icon prefix "${prefix}". Available: lucide, carbon, mdi, phosphor, tabler, f5-brand, hashicorp-flight`
+        `Unknown icon prefix "${prefix}". Available: lucide, carbon, mdi, phosphor, tabler, f5-brand, f5xc, hashicorp-flight`
       );
   }
 
@@ -60,6 +63,8 @@ if (isScoped) {
   const h = icon.height ?? iconData.height ?? 24;
   viewBox = `0 0 ${w} ${h}`;
 }
+
+const isPalette = isScoped && iconData?.info?.palette === true;
 
 const a11yAttrs = label
   ? { 'aria-label': label }
@@ -77,7 +82,7 @@ const inlineStyle = styleParts.length ? styleParts.join('; ') : undefined;
     class={className}
     width="16"
     height="16"
-    fill="currentColor"
+    {...(isPalette ? {} : { fill: "currentColor" })}
     viewBox={viewBox}
     style={inlineStyle}
     set:html={svgBody}

--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -244,7 +244,7 @@ The theme provides a custom `LinkCard` component that supports an optional `icon
 import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
 ```
 
-All seven icon packs are supported via the `prefix:name` syntax. See the [Icon Packages](https://f5xc-salesdemos.github.io/docs-icons/) documentation for the full catalog.
+All eight icon packs are supported via the `prefix:name` syntax. See the [Icon Packages](https://f5xc-salesdemos.github.io/docs-icons/) documentation for the full catalog.
 
 #### Lucide (`lucide:`)
 
@@ -344,6 +344,25 @@ All seven icon packs are supported via the `prefix:name` syntax. See the [Icon P
     icon="f5-brand:security-firewall"
     title="Firewall"
     description="F5 branded firewall icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+</CardGrid>
+
+#### F5 Distributed Cloud (`f5xc:`)
+
+These icons are multi-color and use CSS custom properties for light/dark mode color adaptation.
+
+<CardGrid>
+  <IconLinkCard
+    icon="f5xc:web-app-and-api-protection"
+    title="App & API Protection"
+    description="F5 XC web app and API protection icon."
+    href="https://f5xc-salesdemos.github.io/docs-icons/"
+  />
+  <IconLinkCard
+    icon="f5xc:bot-defense"
+    title="Bot Defense"
+    description="F5 XC bot defense icon."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
 </CardGrid>

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "@iconify-json/ph": "*",
     "@iconify-json/tabler": "*",
     "@robinmordasiewicz/icons-f5-brand": "*",
+    "@robinmordasiewicz/icons-f5xc": "*",
     "@robinmordasiewicz/icons-hashicorp-flight": "*"
   },
   "peerDependenciesMeta": {
@@ -79,6 +80,7 @@
     "@iconify-json/ph": { "optional": true },
     "@iconify-json/tabler": { "optional": true },
     "@robinmordasiewicz/icons-f5-brand": { "optional": true },
+    "@robinmordasiewicz/icons-f5xc": { "optional": true },
     "@robinmordasiewicz/icons-hashicorp-flight": { "optional": true }
   },
   "dependencies": {

--- a/src/utils/resolve-icon.ts
+++ b/src/utils/resolve-icon.ts
@@ -35,12 +35,15 @@ export function resolveIcon(name: string): string {
     case 'f5-brand':
       iconData = require('@robinmordasiewicz/icons-f5-brand/icons.json');
       break;
+    case 'f5xc':
+      iconData = require('@robinmordasiewicz/icons-f5xc/icons.json');
+      break;
     case 'hashicorp-flight':
       iconData = require('@robinmordasiewicz/icons-hashicorp-flight/icons.json');
       break;
     default:
       throw new Error(
-        `Unknown icon prefix "${prefix}". Available: lucide, carbon, mdi, phosphor, tabler, f5-brand, hashicorp-flight`
+        `Unknown icon prefix "${prefix}". Available: lucide, carbon, mdi, phosphor, tabler, f5-brand, f5xc, hashicorp-flight`
       );
   }
 
@@ -51,5 +54,7 @@ export function resolveIcon(name: string): string {
 
   const w = icon.width ?? iconData.width ?? 24;
   const h = icon.height ?? iconData.height ?? 24;
-  return `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 ${w} ${h}" fill="currentColor">${icon.body}</svg>`;
+  const isPalette = iconData.info?.palette === true;
+  const fillAttr = isPalette ? '' : ' fill="currentColor"';
+  return `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 ${w} ${h}"${fillAttr}>${icon.body}</svg>`;
 }

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -47,6 +47,26 @@
   --f5-black-4: #222222;
 }
 
+/* ===== F5 XC Multi-Color Icon Variables ===== */
+:root {
+  --color-N600: #0f1e57;
+  --color-brand: #e4002b;
+  --color-blue-light: #e5eaff;
+  --color-N200: #e6e9f3;
+}
+
+:root:not([data-theme='light']) {
+  --color-N600: #e5eaff;
+  --color-blue-light: #0e41aa;
+  --color-N200: #1a2a6c;
+}
+
+:root[data-theme='light'] {
+  --color-N600: #0f1e57;
+  --color-blue-light: #e5eaff;
+  --color-N200: #e6e9f3;
+}
+
 /* ===== Dark Mode (Starlight default) ===== */
 :root {
   --sl-color-white: var(--f5-white);


### PR DESCRIPTION
## Summary

- Register `f5xc` icon prefix in `Icon.astro` and `resolve-icon.ts` so `f5xc:name` icons resolve correctly
- Add conditional `fill` attribute based on Iconify `info.palette` metadata — monochrome icons keep `fill="currentColor"`, future palette icon sets will omit it
- Add CSS custom properties (`--color-N600`, `--color-brand`, `--color-blue-light`, `--color-N200`) with light/dark mode values matching the f5xc icon package
- Add `@robinmordasiewicz/icons-f5xc` as optional peer dependency
- Add f5xc icon examples to the components docs page

Closes #134

## Test plan

- [ ] Build in Docker dev mode — confirm no errors from f5xc icon resolution
- [ ] Check f5xc icons render with colors in LinkCards (e.g., `f5xc:bot-defense`)
- [ ] Check f5-brand icons still render as monochrome (not broken)
- [ ] Check Lucide/Carbon/MDI/Tabler/Phosphor icons unchanged
- [ ] Verify light/dark mode color adaptation for f5xc icons
- [ ] Verify `resolveIcon('f5xc:bot-defense')` returns SVG with colored paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)