### PR TITLE
fix: move iconData declaration to outer scope to prevent ReferenceError

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -14,13 +14,12 @@ const isScoped = name.includes(':');
 
 let svgBody = '';
 let viewBox = '0 0 24 24';
+let iconData: any;
 
 if (isScoped) {
   const colonIndex = name.indexOf(':');
   const prefix = name.slice(0, colonIndex);
   const iconName = name.slice(colonIndex + 1);
-
-  let iconData: any;
 
   switch (prefix) {
     case 'lucide':


### PR DESCRIPTION
## Summary

- Move `let iconData: any;` declaration before the `if (isScoped)` block so it's accessible for the `isPalette` check outside the block

The `isPalette` check added in #135 referenced `iconData` outside its block scope, causing `ReferenceError: iconData is not defined` during the Astro build.

Closes #136

## Test plan

- [ ] Pages Deploy workflow succeeds without ReferenceError
- [ ] f5xc icons render correctly
- [ ] Non-scoped (Starlight built-in) icons still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)