### PR TITLE
feat: enable per-icon color detection for multi-color icon rendering

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -1,5 +1,6 @@
 ---
 import { Icon as StarlightIcon } from '@astrojs/starlight/components';
+import { hasExplicitColors } from '../src/utils/resolve-icon';
 
 interface Props {
   name: string;
@@ -63,7 +64,7 @@ if (isScoped) {
   viewBox = `0 0 ${w} ${h}`;
 }
 
-const isPalette = isScoped && iconData?.info?.palette === true;
+const isPalette = isScoped && (iconData?.info?.palette === true || hasExplicitColors(svgBody));
 
 const a11yAttrs = label
   ? { 'aria-label': label }

--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -371,15 +371,15 @@ These icons are multi-color and use CSS custom properties for light/dark mode co
 
 <CardGrid>
   <LinkCard
-    icon="hashicorp-flight:terraform"
+    icon="hashicorp-flight:terraform-color"
     title="Terraform"
     description="HashiCorp Terraform icon."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
   <LinkCard
-    icon="hashicorp-flight:cloud"
-    title="Cloud Infrastructure"
-    description="HashiCorp cloud icon."
+    icon="hashicorp-flight:consul-color"
+    title="Consul"
+    description="HashiCorp Consul icon."
     href="https://f5xc-salesdemos.github.io/docs-icons/"
   />
 </CardGrid>

--- a/src/utils/resolve-icon.ts
+++ b/src/utils/resolve-icon.ts
@@ -3,6 +3,15 @@ import { createRequire } from 'module';
 const require = createRequire(import.meta.url);
 
 /**
+ * Returns true if the SVG body contains explicit color fills (hex, CSS vars,
+ * gradient refs, named colors) — i.e. anything other than "none" or "currentColor".
+ */
+export function hasExplicitColors(body: string): boolean {
+  const fills = body.match(/fill="([^"]*)"/g) || [];
+  return fills.some(f => f !== 'fill="none"' && f !== 'fill="currentColor"');
+}
+
+/**
  * Resolves a `prefix:name` icon identifier to a complete SVG string
  * using the installed Iconify JSON packages. Designed for synchronous
  * use at module scope (e.g. in config.ts default values).
@@ -54,7 +63,7 @@ export function resolveIcon(name: string): string {
 
   const w = icon.width ?? iconData.width ?? 24;
   const h = icon.height ?? iconData.height ?? 24;
-  const isPalette = iconData.info?.palette === true;
+  const isPalette = iconData.info?.palette === true || hasExplicitColors(icon.body);
   const fillAttr = isPalette ? '' : ' fill="currentColor"';
   return `<svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 ${w} ${h}"${fillAttr}>${icon.body}</svg>`;
 }


### PR DESCRIPTION
## Summary
- Adds `hasExplicitColors()` helper in `src/utils/resolve-icon.ts` that scans SVG body for explicit color fills (hex, CSS vars, gradient refs, named colors)
- Updates palette check in both `resolve-icon.ts` and `components/Icon.astro` to skip `fill="currentColor"` for icons with embedded colors
- Updates HashiCorp Flight examples in `docs/components.mdx` to use `-color` variant icons (`terraform-color`, `consul-color`)

## Test plan
- [ ] HashiCorp Flight color icons (`terraform-color`, `consul-color`) render in their native colors
- [ ] f5xc icons still render in color (no regression — they use CSS var fills on paths)
- [ ] Monochrome icons (lucide, carbon, mdi, phosphor, tabler) still inherit text color correctly
- [ ] Both light and dark modes display correctly
- [ ] CI Pages Deploy builds without errors

Closes #141

🤖 Generated with [Claude Code](https://claude.com/claude-code)