### PR TITLE
feat: improve LinkCard icon sizing and responsiveness

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -14,7 +14,7 @@ const { title, description, icon, ...attributes } = Astro.props;
 <div class:list={['sl-link-card', { 'has-icon': !!icon }]}>
 	{icon && (
 		<span class="card-icon">
-			<Icon name={icon} size="1.5em" />
+			<Icon name={icon} />
 		</span>
 	)}
 	<span class="sl-flex stack">
@@ -78,6 +78,15 @@ const { title, description, icon, ...attributes } = Astro.props;
 		color: var(--sl-color-white);
 		display: flex;
 		align-items: center;
+		align-self: stretch;
+	}
+
+	.card-icon :global(svg) {
+		width: auto;
+		height: 100%;
+		min-height: 1.5rem;
+		max-height: 3rem;
+		aspect-ratio: 1;
 	}
 
 	/* Hover state */


### PR DESCRIPTION
Closes #145

Improve the LinkCard component's icon handling by removing the hardcoded size attribute and implementing responsive CSS-based scaling.

**Changes:**
- Remove  from Icon component for flexible sizing
- Add responsive SVG styling with min/max height constraints
- Use  to maintain square icon proportions  
- Add  to fill available vertical space

**Benefits:**
- Icons now scale proportionally with card height
- Better responsive behavior across different screen sizes
- Cleaner component interface without hardcoded dimensions