### PR TITLE
feat: apply consistent --f5-shadow-low across Card, LinkCard, and Badge components

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -34,8 +34,10 @@ const { title, description, icon, ...attributes } = Astro.props;
 		border: 1px solid var(--sl-color-gray-5);
 		border-radius: 0.5rem;
 		padding: 1rem;
-		box-shadow: var(--sl-shadow-sm);
+		box-shadow: var(--f5-shadow-low);
 		position: relative;
+		transition: box-shadow var(--f5-transition-base),
+		            transform var(--f5-transition-base);
 	}
 
 	.sl-link-card.has-icon {
@@ -93,6 +95,8 @@ const { title, description, icon, ...attributes } = Astro.props;
 	.sl-link-card:hover {
 		background: var(--sl-color-gray-7, var(--sl-color-gray-6));
 		border-color: var(--sl-color-gray-2);
+		box-shadow: var(--f5-shadow-mid);
+		transform: translateY(-1px);
 	}
 
 	.sl-link-card:hover .icon {

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -247,6 +247,22 @@ h4, h5, h6 {
   box-shadow: var(--f5-shadow-low);
 }
 
+/* Starlight Card — consistent shadow */
+.card {
+  box-shadow: var(--f5-shadow-low);
+  transition: box-shadow var(--f5-transition-base),
+              transform var(--f5-transition-base);
+}
+.card:hover {
+  box-shadow: var(--f5-shadow-mid);
+  transform: translateY(-1px);
+}
+
+/* Badge — consistent shadow */
+.sl-badge {
+  box-shadow: var(--f5-shadow-low);
+}
+
 .expressive-code .frame {
   --header-border-radius: var(--f5-radius-md);
   border-radius: var(--f5-radius-md);


### PR DESCRIPTION
## Summary
- Switch LinkCard from Starlight `--sl-shadow-sm` to F5 `--f5-shadow-low` token, add hover lift to `--f5-shadow-mid`
- Add `--f5-shadow-low` with hover lift to Starlight `<Card>` component
- Add subtle `--f5-shadow-low` to `.sl-badge` (no hover — inline, non-interactive)

Closes #147

## Test plan
- [ ] Verify asides, cards, link cards, and badges all show subtle shadow in light mode
- [ ] Hover over Cards and LinkCards — shadow lifts to mid with translateY(-1px)
- [ ] Toggle to dark mode — shadows adapt correctly using dark-mode token values
- [ ] Badges have subtle shadow without hover effect
- [ ] Existing `.swatch` and `.icon-card` hover behavior unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)