### PR TITLE
fix: resolve LinkCard icon hover flicker

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -84,11 +84,8 @@ const { title, description, icon, ...attributes } = Astro.props;
 	}
 
 	.card-icon :global(svg) {
+		height: 1.5rem;
 		width: auto;
-		height: 100%;
-		min-height: 1.5rem;
-		max-height: 3rem;
-		aspect-ratio: 1;
 	}
 
 	/* Hover state */


### PR DESCRIPTION
## Summary
- Replace percentage-based SVG `height: 100%` with definite `height: 1.5rem` to eliminate circular layout dependency causing icon flicker on hover
- Remove unnecessary `min-height`, `max-height`, and `aspect-ratio: 1` constraints

## Test plan
- [ ] Icons render at 24px (1.5rem) — not too small
- [ ] Hovering over LinkCard does not change icon size
- [ ] Rapid mouse on/off card edge produces no flickering
- [ ] LinkCards without icons still render correctly
- [ ] Non-square icons preserve natural aspect ratio via `width: auto`

Closes #151

🤖 Generated with [Claude Code](https://claude.com/claude-code)