### PR TITLE
fix: use absolute positioning for LinkCard icon to fill card height

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -78,14 +78,17 @@ const { title, description, icon, ...attributes } = Astro.props;
 
 	.card-icon {
 		color: var(--sl-color-white);
-		display: flex;
-		align-items: center;
 		align-self: stretch;
+		position: relative;
+		aspect-ratio: 1;
+		max-height: 3rem;
 	}
 
 	.card-icon :global(svg) {
-		height: 1.5rem;
-		width: auto;
+		position: absolute;
+		inset: 0;
+		width: 100%;
+		height: 100%;
 	}
 
 	/* Hover state */


### PR DESCRIPTION
## Summary

Closes #153

- Uses absolute positioning to break the circular layout dependency between the SVG icon and its grid container, so the icon fills the card height on first render without hover flicker
- Replaces the fixed `height: 1.5rem` (PR #152 regression) with `aspect-ratio: 1` + `max-height: 3rem` for responsive sizing capped at a reasonable maximum
- Removes unnecessary `display: flex; align-items: center` since the SVG now fills its container via `position: absolute; inset: 0`

## Test plan

- [ ] Initial render: icon fills card height (not stuck at 16px/24px), capped at 3rem
- [ ] Hover: icon does NOT change size or flicker
- [ ] Rapid mouse on/off: no flickering at card edges
- [ ] Cards without `icon` prop render normally
- [ ] Various icon packs (lucide, carbon, f5-brand, f5xc) display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)