### PR TITLE
fix: widen mega-menu flyout to prevent title word-wrap

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -711,3 +711,8 @@ summary:focus-visible {
   transition: opacity var(--f5-transition-base),
               color var(--f5-transition-base);
 }
+
+/* Widen mega-menu flyout to prevent title word-wrap in two-column layouts */
+.smm-viewport {
+  max-width: min(90vw, 800px);
+}


### PR DESCRIPTION
## Summary
- Override `.smm-viewport` max-width from `min(90vw, 700px)` to `min(90vw, 800px)` in `styles/custom.css`
- Gives each column ~380px instead of ~330px in two-column mega-menu layouts, preventing title word-wrap on items like "Bot Defense Advanced" and "Multi-Cloud Networking"

## Test plan
- [ ] Hover over "Security" and "Networking" menus — confirm no title word-wrap in two-column flyouts
- [ ] Verify "Platform" and "Resources" (single-column) still display correctly
- [ ] Resize browser to narrow widths — `90vw` cap should prevent overflow on smaller screens

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)