### PR TITLE
fix: set min-width on mega-menu flyout for two-column layouts

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -712,7 +712,11 @@ summary:focus-visible {
               color var(--f5-transition-base);
 }
 
-/* Widen mega-menu flyout to prevent title word-wrap in two-column layouts */
+/* Widen mega-menu flyout to prevent title word-wrap in two-column layouts.
+   Radix JS sets --radix-navigation-menu-viewport-width based on intrinsic
+   content measurement (~320px), so max-width alone cannot force expansion.
+   We override min-width to ensure two-column grids have adequate room. */
 .smm-viewport {
+  min-width: min(90vw, 650px);
   max-width: min(90vw, 800px);
 }


### PR DESCRIPTION
## Summary
- Add `min-width: min(90vw, 650px)` to `.smm-viewport` so Radix NavigationMenu flyouts expand beyond intrinsic content measurement (~320px)
- Gives each two-column grid column ~300px, preventing title word-wrap in Security and Networking flyouts
- Keeps existing `max-width: min(90vw, 800px)` ceiling and `90vw` responsive cap

## Test plan
- [ ] Hover **Security** flyout — two columns should show titles without word-wrapping
- [ ] Hover **Networking** flyout — same check
- [ ] Hover **Platform** flyout — single column should still look reasonable at wider width
- [ ] Hover **Resources** flyout — verify it renders correctly
- [ ] Check responsive behavior — resize browser to narrow widths, confirm `90vw` cap prevents overflow

Closes #161

🤖 Generated with [Claude Code](https://claude.com/claude-code)