### PR TITLE
fix: add sidebar order to index.mdx and close ordering gap

### DIFF
--- a/docs/astro-config.mdx
+++ b/docs/astro-config.mdx
@@ -2,7 +2,7 @@
 title: Astro Configuration
 description: Reference for the plugin-based Astro/Starlight configuration factory.
 sidebar:
-  order: 3
+  order: 4
 ---
 
 Content repositories do not maintain their own `astro.config.mjs`. Instead, they import a configuration factory from the `f5xc-docs-theme` npm package that returns a complete Astro config with Starlight, eight bundled plugins, and all theme defaults.

--- a/docs/build-pipeline.mdx
+++ b/docs/build-pipeline.mdx
@@ -2,7 +2,7 @@
 title: Build Pipeline
 description: How content repositories consume the theme at build time through the Docker builder and npm package.
 sidebar:
-  order: 2
+  order: 3
 ---
 
 This page describes how content repositories consume the `f5xc-docs-theme` npm package to produce fully branded documentation sites.

--- a/docs/colors.mdx
+++ b/docs/colors.mdx
@@ -2,7 +2,7 @@
 title: Colors
 description: Color palette reference for theme development — primary colors, tints, shades, CMYK, LESS variables, and Starlight CSS custom property mapping.
 sidebar:
-  order: 5
+  order: 6
 ---
 
 The full range of our color palette is used in graphics and illustrations, exploring unique and modern combinations as well as monochromatic contrasts. It can be used to highlight a specific topic or point of emphasis.

--- a/docs/environment-variables.mdx
+++ b/docs/environment-variables.mdx
@@ -2,7 +2,7 @@
 title: Environment Variables
 description: Reference for all environment variables supported by the theme.
 sidebar:
-  order: 1
+  order: 2
 ---
 
 The theme reads environment variables at build time from `config.ts` and custom components. Content repositories set these in their GitHub Actions workflow to customize each site without modifying the configuration.

--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -1,6 +1,8 @@
 ---
 title: Theme
 description: Shared branding and styling layer for all Cloud documentation sites.
+sidebar:
+  order: 1
 hero:
   title: Theme
   tagline: Shared branding, fonts, and styling for every Cloud documentation site

--- a/docs/logo.mdx
+++ b/docs/logo.mdx
@@ -2,7 +2,7 @@
 title: Logo
 description: How the logo is configured and how to replace it.
 sidebar:
-  order: 4
+  order: 5
 ---
 
 The theme displays a logo in the site header of every documentation site.


### PR DESCRIPTION
## Summary
- Add `sidebar: { order: 1 }` to `docs/index.mdx` so it appears first in the sidebar
- Shift orders 1-5 up by one for environment-variables, build-pipeline, astro-config, logo, and colors pages
- Closes the gap at position 6 (colors was 5, typography was 7)

Closes #167

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have linked a GitHub issue to this PR
- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] New and existing tests pass

## Test plan
- [ ] Verify sidebar shows Theme (index) as the first item
- [ ] Verify previous/next navigation at bottom of pages follows correct sequence
- [ ] Confirm no gaps in ordering (1 through 12, then 99)

🤖 Generated with [Claude Code](https://claude.com/claude-code)