### PR TITLE
fix: hide index page from sidebar

### DIFF
--- a/docs/index.mdx
+++ b/docs/index.mdx
@@ -3,6 +3,7 @@ title: Theme
 description: Shared branding and styling layer for all Cloud documentation sites.
 sidebar:
   order: 1
+  hidden: true
 hero:
   title: Theme
   tagline: Shared branding, fonts, and styling for every Cloud documentation site


### PR DESCRIPTION
## Summary
- Add `hidden: true` to the sidebar frontmatter in `docs/index.mdx`
- The index/hero page should not appear in the sidebar navigation

Closes #169

## Type of change
- [x] Bug fix (non-breaking change that fixes an issue)

## Checklist
- [x] I have linked a GitHub issue to this PR
- [x] My changes follow the existing code style
- [x] I have tested my changes locally
- [x] New and existing tests pass

## Test plan
- [ ] Verify the index page no longer appears in the sidebar
- [ ] Verify the index page is still accessible via the site title link

🤖 Generated with [Claude Code](https://claude.com/claude-code)