### PR TITLE
fix: use monochrome X icon to fix dark mode visibility

### DIFF
--- a/components/Footer.astro
+++ b/components/Footer.astro
@@ -10,7 +10,7 @@ import Icon from './Icon.astro';
     <Icon name="hashicorp-flight:facebook-color" size="1.5rem" />
   </a>
   <a href="https://x.com/F5" target="_blank" rel="noopener noreferrer" aria-label="X">
-    <Icon name="hashicorp-flight:twitter-x-color" size="1.5rem" />
+    <Icon name="hashicorp-flight:twitter-x" size="1.5rem" />
   </a>
   <a href="https://www.linkedin.com/company/f5/" target="_blank" rel="noopener noreferrer" aria-label="LinkedIn">
     <Icon name="hashicorp-flight:linkedin-color" size="1.5rem" />


### PR DESCRIPTION
## Summary
- Switch footer X.com icon from `twitter-x-color` (hardcoded `fill="#000"`) to `twitter-x` (uses `fill="currentColor"`)
- The color variant is invisible against dark backgrounds; the monochrome variant adapts to both themes
- No changes needed in docs-icons — the correct icon already exists in the hashicorp-flight package

## Test plan
- [ ] Verify X icon is visible in light mode
- [ ] Verify X icon is visible in dark mode
- [ ] Verify other social icons (Facebook, LinkedIn, Instagram, YouTube) are unchanged

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)