### PR TITLE
fix: remove double border on mermaid diagrams

### DIFF
--- a/docs/mermaid.mdx
+++ b/docs/mermaid.mdx
@@ -115,6 +115,19 @@ Mermaid diagrams are wrapped in a styled container with rounded corners and a la
 }
 ```
 
+### Pre Element Reset
+
+Starlight's default `<pre>` styling is stripped from the mermaid wrapper so only the outer container border is visible:
+
+```css
+.mermaid-container pre.mermaid {
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+}
+```
+
 ### SVG Background Forcing
 
 The SVG inside is forced to a white background for dark mode compatibility:

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -242,6 +242,14 @@ h4, h5, h6 {
   fill: white !important;
 }
 
+/* Strip Starlight's default <pre> styling from the mermaid wrapper to prevent double border */
+.mermaid-container pre.mermaid {
+  border: none;
+  padding: 0;
+  margin: 0;
+  background: transparent;
+}
+
 .starlight-aside {
   border-radius: var(--f5-radius-md);
   box-shadow: var(--f5-shadow-low);


### PR DESCRIPTION
## Summary
- Strip Starlight's inherited `<pre>` border/padding/margin from mermaid wrapper to eliminate double border
- Add CSS reset rule `.mermaid-container pre.mermaid` in `styles/custom.css`
- Document the new rule in `docs/mermaid.mdx` CSS Reference section

## Related Issue
Closes #179

## Type of Change
- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature causing existing functionality to change)
- [ ] Documentation update

## Test plan
- [ ] Visit `/mermaid/` page on the docs site after deployment
- [ ] Verify each diagram type shows only a single thin rounded border (no inner rectangular border)
- [ ] Check both light and dark mode for correct rendering
- [ ] Confirm `.mermaid-container` padding, shadow, and border-radius are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)