### PR TITLE
fix: remove CSS fill override that strips Mermaid diagram colors

### DIFF
--- a/docs/mermaid.mdx
+++ b/docs/mermaid.mdx
@@ -144,6 +144,5 @@ The SVG inside is forced to a white background for dark mode compatibility:
 - `.mermaid-container` has white SVG background in dark mode
 - Container border uses `--sl-color-gray-5`
 - Container has 0.75rem border radius and layered box shadow
-- `rect` and `polygon` elements have forced white fill in dark mode
 - Diagrams are readable in both light and dark themes
 - Mermaid CDN script loads and renders SVGs on page load

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -236,12 +236,6 @@ h4, h5, h6 {
   border-radius: var(--f5-radius-md);
 }
 
-/* fill is a valid SVG presentation property (CSS Masking/SVG spec) */
-.mermaid-container svg rect,
-.mermaid-container svg polygon {
-  fill: white !important;
-}
-
 /* Strip Starlight's default <pre> styling from the mermaid wrapper to prevent double border */
 .mermaid-container pre.mermaid {
   border: none;


### PR DESCRIPTION
## Summary
- Remove `fill: white !important` CSS rule on `svg rect` and `svg polygon` elements that was overriding Mermaid's neutral theme color palette
- Update `docs/mermaid.mdx` to remove the corresponding documentation reference
- Container-level SVG background (`background: white !important`) remains for dark mode compatibility

## Test plan
- [ ] Verify Mermaid diagrams show neutral theme colors (light blue/gray node fills, colored borders) at https://f5xc-salesdemos.github.io/docs-theme/mermaid/
- [ ] Check both light and dark mode — diagrams should render identically on white canvas
- [ ] Inspect computed styles: `svg rect` elements should have Mermaid-assigned fills, not `white`

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)