### PR TITLE
fix: increase mega-menu icon size to match title+description height

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -722,3 +722,10 @@ summary:focus-visible {
   min-width: min(90vw, 650px);
   max-width: min(90vw, 800px);
 }
+
+/* Scale mega-menu icons to match the height of the title + description text block */
+.smm-link-icon {
+  width: 2.5rem;
+  height: 2.5rem;
+  margin-top: 0;
+}


### PR DESCRIPTION
## Summary
- Increases `.smm-link-icon` from `1.25rem` (20px) to `2.5rem` (40px) via CSS override in `styles/custom.css`
- Icons now visually span the same height as the title + description text block (~2.4rem)
- SVGs scale automatically via existing `width: 100%; height: 100%` rule

## Test plan
- [ ] Open any mega-menu dropdown (Security, Networking, etc.) and confirm icons are ~40px tall
- [ ] Verify icons don't overflow or distort — SVGs should scale cleanly
- [ ] Check mobile view — `.smm-mobile-link-icon` is unaffected

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)