### PR TITLE
feat: support DOCS_MARKDOWN_CONTENT env var for component override

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,7 +21,8 @@ export default function f5xcDocsTheme(): StarlightPlugin {
             EditLink: 'f5xc-docs-theme/components/EditLink.astro',
             Footer: 'f5xc-docs-theme/components/Footer.astro',
             SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
-            MarkdownContent: 'f5xc-docs-theme/components/MarkdownContent.astro',
+            MarkdownContent: process.env.DOCS_MARKDOWN_CONTENT
+              || 'f5xc-docs-theme/components/MarkdownContent.astro',
           },
         });
         logger.info('F5 XC docs theme loaded');


### PR DESCRIPTION
## Summary

- Add `DOCS_MARKDOWN_CONTENT` env var support in `index.ts` to allow overriding the `MarkdownContent` component path at build time
- Falls back to the default theme component (`f5xc-docs-theme/components/MarkdownContent.astro`) when not set
- Follows the existing env var pattern (`DOCS_TITLE`, `DOCS_BASE`, etc.)

## Linked Issue

Closes #185

## Motivation

Enables the PlaceholderForm auto-injection feature: `docs-builder`'s entrypoint sets this env var when a content repo provides `placeholders.json`, pointing to a custom `MarkdownContent.astro` that wraps the theme's version with the PlaceholderForm accordion.

## Test plan

- [ ] Verify existing sites build without `DOCS_MARKDOWN_CONTENT` set (fallback to default)
- [ ] Verify `DOCS_MARKDOWN_CONTENT=./src/overrides/MarkdownContent.astro` correctly overrides the component
- [ ] Semantic release publishes new npm version

🤖 Generated with [Claude Code](https://claude.com/claude-code)