### PR TITLE
feat: register icon packs with Mermaid and add icon diagram examples

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -258,7 +258,41 @@ const defaultHead: HeadEntry[] = [
   {
     tag: 'script',
     attrs: { type: 'module' },
-    content: `import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs'; mermaid.initialize({ startOnLoad: true, theme: 'neutral' });`,
+    content: `
+import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
+
+mermaid.registerIconPacks([
+  { name: 'hashicorp-flight', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-hashicorp-flight/icons.json').then(r => r.json()) },
+  { name: 'f5-brand', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-f5-brand/icons.json').then(r => r.json()) },
+  { name: 'f5xc', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-f5xc/icons.json').then(r => r.json()) },
+  { name: 'carbon', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-carbon/icons.json').then(r => r.json()) },
+  { name: 'lucide', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-lucide/icons.json').then(r => r.json()) },
+  { name: 'mdi', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-mdi/icons.json').then(r => r.json()) },
+  { name: 'phosphor', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-phosphor/icons.json').then(r => r.json()) },
+  { name: 'tabler', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-tabler/icons.json').then(r => r.json()) },
+]);
+
+mermaid.initialize({
+  startOnLoad: true,
+  theme: 'base',
+  themeVariables: {
+    primaryColor: '#e8ecf4',
+    primaryTextColor: '#1a1a2e',
+    primaryBorderColor: '#0e41aa',
+    lineColor: '#0e41aa',
+    secondaryColor: '#fff5eb',
+    secondaryTextColor: '#1a1a2e',
+    secondaryBorderColor: '#f29a36',
+    tertiaryColor: '#f0e6f6',
+    tertiaryTextColor: '#1a1a2e',
+    tertiaryBorderColor: '#62228b',
+    noteBkgColor: '#ffe4c4',
+    noteTextColor: '#1a1a2e',
+    noteBorderColor: '#f29a36',
+    fontFamily: 'F5, system-ui, sans-serif',
+  },
+});
+`,
   },
 ];
 

--- a/docs/mermaid.mdx
+++ b/docs/mermaid.mdx
@@ -98,6 +98,93 @@ gantt
     Production Deploy :c2, after c1, 2d
 ```
 
+## Flowchart with Icons
+
+Use the `@{ icon: 'pack:name' }` syntax to add icons from any registered icon pack to flowchart nodes.
+
+```mermaid
+flowchart LR
+  consul@{ icon: 'hashicorp-flight:consul', label: 'Consul' }
+  terraform@{ icon: 'hashicorp-flight:terraform', label: 'Terraform' }
+  vault@{ icon: 'hashicorp-flight:vault', label: 'Vault' }
+  nomad@{ icon: 'hashicorp-flight:nomad', label: 'Nomad' }
+
+  terraform --> consul
+  terraform --> vault
+  terraform --> nomad
+  consul <--> vault
+```
+
+## Architecture Diagram
+
+The `architecture-beta` diagram type supports service and group definitions with icon-decorated nodes.
+
+```mermaid
+architecture-beta
+  group cloud(carbon:cloud-services)[Cloud Infrastructure]
+
+  service gateway(carbon:gateway--api)[API Gateway] in cloud
+  service app(carbon:application)[App Server] in cloud
+  service db(carbon:data--base)[Database] in cloud
+  service cache(carbon:data--cache)[Cache] in cloud
+
+  gateway:R --> L:app
+  app:R --> L:db
+  app:B --> T:cache
+```
+
+## Network Topology
+
+Multi-cloud network diagrams using architecture groups and cloud provider icons.
+
+```mermaid
+architecture-beta
+  group aws(carbon:logo--aws)[AWS Region]
+  group azure(carbon:logo--azure)[Azure Region]
+
+  service lb(carbon:load--balancer--global)[Global LB]
+  service web1(carbon:virtual--machine)[Web Tier] in aws
+  service db1(carbon:data--base)[Primary DB] in aws
+  service web2(carbon:virtual--machine)[Web Tier] in azure
+  service db2(carbon:data--base)[Replica DB] in azure
+
+  lb:R --> L:web1
+  lb:B --> T:web2
+  web1:R --> L:db1
+  web2:R --> L:db2
+  db1:B --> T:db2
+```
+
+## Icon Reference
+
+The following icon packs are registered and available in Mermaid diagrams. Icons are loaded lazily from CDN only when referenced.
+
+| Pack Name | npm Package | Example Icons |
+|-----------|-------------|---------------|
+| `hashicorp-flight` | `@robinmordasiewicz/icons-hashicorp-flight` | `terraform`, `consul`, `vault`, `nomad`, `waypoint`, `packer` |
+| `f5-brand` | `@robinmordasiewicz/icons-f5-brand` | F5 product and brand icons |
+| `f5xc` | `@robinmordasiewicz/icons-f5xc` | F5 Distributed Cloud service icons |
+| `carbon` | `@robinmordasiewicz/icons-carbon` | `cloud-services`, `data--base`, `application`, `gateway--api`, `security` |
+| `lucide` | `@robinmordasiewicz/icons-lucide` | `server`, `database`, `shield`, `globe`, `lock`, `cloud` |
+| `mdi` | `@robinmordasiewicz/icons-mdi` | `server`, `database`, `shield`, `cloud`, `lock`, `network` |
+| `phosphor` | `@robinmordasiewicz/icons-phosphor` | `cloud`, `database`, `shield`, `globe`, `lock` |
+| `tabler` | `@robinmordasiewicz/icons-tabler` | `server`, `database`, `shield`, `cloud`, `lock`, `network` |
+
+### Usage Syntax
+
+In **flowcharts**, use the `@{}` node syntax:
+
+```
+nodeName@{ icon: 'pack:icon-name', label: 'Display Label' }
+```
+
+In **architecture diagrams**, use the icon in service/group definitions:
+
+```
+service myService(pack:icon-name)[Label]
+group myGroup(pack:icon-name)[Label]
+```
+
 ## CSS Reference
 
 ### Container Styling


### PR DESCRIPTION
## Summary

- Register all 8 published icon packs with Mermaid's `registerIconPacks()` API using lazy CDN loaders
- Apply F5-branded `base` theme with `themeVariables` derived from design tokens
- Add documentation examples: icon flowcharts, architecture diagrams, network topology, and icon reference table

## Test plan

- [ ] Verify existing diagrams (flowchart, sequence, pie, class, state, gantt) render correctly with new `base` theme
- [ ] Verify icon flowchart renders HashiCorp Flight icons from CDN
- [ ] Verify architecture diagrams render Carbon icons from CDN
- [ ] Verify white SVG background maintained in both light and dark site themes
- [ ] Verify icon packs are lazily loaded (no network requests until diagram references a pack)

Closes #193

🤖 Generated with [Claude Code](https://claude.com/claude-code)