### PR TITLE
feat: add AI section to mega-menu with api-mcp link

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -222,6 +222,25 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
     },
   },
   {
+    label: 'AI',
+    content: {
+      layout: 'list',
+      categories: [
+        {
+          title: 'AI Tools',
+          items: [
+            {
+              label: 'API MCP Server',
+              description: 'MCP server for F5 XC API',
+              href: 'https://f5xc-salesdemos.github.io/api-mcp/',
+              icon: resolveIcon('f5xc:ai_assistant_logo'),
+            },
+          ],
+        },
+      ],
+    },
+  },
+  {
     label: 'Resources',
     content: {
       layout: 'list',


### PR DESCRIPTION
## Summary
- Add new "AI" top-level menu item to mega-menu navigation between Platform and Resources
- Include API MCP Server link pointing to the api-mcp docs site
- Use `f5xc:ai_assistant_logo` icon for the AI section

Closes #201

## Test plan
- [ ] Verify mega-menu renders "AI" section between "Platform" and "Resources"
- [ ] Verify API MCP Server link navigates to https://f5xc-salesdemos.github.io/api-mcp/
- [ ] Verify icon renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)