### PR TITLE
feat: update API docs nav link to api-protection

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -77,7 +77,7 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
             {
               label: 'API Security',
               description: 'API discovery and protection',
-              href: 'https://f5xc-salesdemos.github.io/api/',
+              href: 'https://f5xc-salesdemos.github.io/api-protection/',
               icon: resolveIcon('f5xc:application-traffic-insight'),
             },
             {


### PR DESCRIPTION
## Summary
- Updates mega-menu navigation href from `/api/` to `/api-protection/` after repo rename

## Test plan
- [ ] CI checks pass
- [ ] After semantic-release, all content sites rebuild with updated nav link

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)