### PR TITLE
feat!: rename package to @f5xc-salesdemos/docs-theme

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -20,9 +20,9 @@ jobs:
         run: |
           TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
-          echo "Checking npm for f5xc-docs-theme@${VERSION}..."
+          echo "Checking npm for @f5xc-salesdemos/docs-theme@${VERSION}..."
           for i in 1 2 3 4 5; do
-            if npm view "f5xc-docs-theme@${VERSION}" version 2>/dev/null; then
+            if npm view "@f5xc-salesdemos/docs-theme@${VERSION}" version 2>/dev/null; then
               echo "Version ${VERSION} confirmed on npm"
               exit 0
             fi

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,3 +1,3 @@
-import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
+import { createF5xcDocsConfig } from '@f5xc-salesdemos/docs-theme/config';
 
 export default createF5xcDocsConfig();

--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -39,13 +39,13 @@ if (isScoped) {
       iconData = (await import('@iconify-json/tabler/icons.json')).default;
       break;
     case 'f5-brand':
-      iconData = (await import('@robinmordasiewicz/icons-f5-brand/icons.json')).default;
+      iconData = (await import('@f5xc-salesdemos/icons-f5-brand/icons.json')).default;
       break;
     case 'f5xc':
-      iconData = (await import('@robinmordasiewicz/icons-f5xc/icons.json')).default;
+      iconData = (await import('@f5xc-salesdemos/icons-f5xc/icons.json')).default;
       break;
     case 'hashicorp-flight':
-      iconData = (await import('@robinmordasiewicz/icons-hashicorp-flight/icons.json')).default;
+      iconData = (await import('@f5xc-salesdemos/icons-hashicorp-flight/icons.json')).default;
       break;
     default:
       throw new Error(

--- a/config.ts
+++ b/config.ts
@@ -281,14 +281,14 @@ const defaultHead: HeadEntry[] = [
 import mermaid from 'https://cdn.jsdelivr.net/npm/mermaid@11/dist/mermaid.esm.min.mjs';
 
 mermaid.registerIconPacks([
-  { name: 'hashicorp-flight', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-hashicorp-flight/icons.json').then(r => r.json()) },
-  { name: 'f5-brand', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-f5-brand/icons.json').then(r => r.json()) },
-  { name: 'f5xc', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-f5xc/icons.json').then(r => r.json()) },
-  { name: 'carbon', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-carbon/icons.json').then(r => r.json()) },
-  { name: 'lucide', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-lucide/icons.json').then(r => r.json()) },
-  { name: 'mdi', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-mdi/icons.json').then(r => r.json()) },
-  { name: 'phosphor', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-phosphor/icons.json').then(r => r.json()) },
-  { name: 'tabler', loader: () => fetch('https://cdn.jsdelivr.net/npm/@robinmordasiewicz/icons-tabler/icons.json').then(r => r.json()) },
+  { name: 'hashicorp-flight', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-hashicorp-flight/icons.json').then(r => r.json()) },
+  { name: 'f5-brand', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-f5-brand/icons.json').then(r => r.json()) },
+  { name: 'f5xc', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-f5xc/icons.json').then(r => r.json()) },
+  { name: 'carbon', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-carbon/icons.json').then(r => r.json()) },
+  { name: 'lucide', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-lucide/icons.json').then(r => r.json()) },
+  { name: 'mdi', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-mdi/icons.json').then(r => r.json()) },
+  { name: 'phosphor', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-phosphor/icons.json').then(r => r.json()) },
+  { name: 'tabler', loader: () => fetch('https://cdn.jsdelivr.net/npm/@f5xc-salesdemos/icons-tabler/icons.json').then(r => r.json()) },
 ]);
 
 mermaid.initialize({
@@ -325,7 +325,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
     || (process.env.LLMS_OPTIONAL_LINKS ? JSON.parse(process.env.LLMS_OPTIONAL_LINKS) : []);
   const megaMenuItems = options.megaMenuItems || defaultMegaMenuItems;
   const head = options.head || defaultHead;
-  const logo = options.logo || { src: 'f5xc-docs-theme/assets/f5-distributed-cloud.svg' };
+  const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/f5-distributed-cloud.svg' };
   const additionalRemarkPlugins = options.additionalRemarkPlugins || [];
   const additionalIntegrations = options.additionalIntegrations || [];
 

--- a/docs/astro-config.mdx
+++ b/docs/astro-config.mdx
@@ -5,14 +5,14 @@ sidebar:
   order: 4
 ---
 
-Content repositories do not maintain their own `astro.config.mjs`. Instead, they import a configuration factory from the `f5xc-docs-theme` npm package that returns a complete Astro config with Starlight, eight bundled plugins, and all theme defaults.
+Content repositories do not maintain their own `astro.config.mjs`. Instead, they import a configuration factory from the `@f5xc-salesdemos/docs-theme` npm package that returns a complete Astro config with Starlight, eight bundled plugins, and all theme defaults.
 
 ## Consuming the Theme
 
 A content repo's `astro.config.mjs` (provided by the Docker builder) is a thin wrapper:
 
 ```js
-import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
+import { createF5xcDocsConfig } from '@f5xc-salesdemos/docs-theme/config';
 
 export default createF5xcDocsConfig();
 ```
@@ -51,7 +51,7 @@ interface F5xcDocsConfigOptions {
 | `additionalRemarkPlugins` | `[]` | Extra remark plugins added after remark-mermaid |
 | `megaMenuItems` | Built-in Products/Solutions/Docs/Support menu | Top-level mega menu entries |
 | `head` | Mermaid CDN `<script>` tag | Custom `<head>` entries |
-| `logo` | `f5xc-docs-theme/assets/github-avatar.png` | Sidebar logo (single src or light/dark pair) |
+| `logo` | `@f5xc-salesdemos/docs-theme/assets/github-avatar.png` | Sidebar logo (single src or light/dark pair) |
 
 ## Bundled Starlight Plugins
 
@@ -62,14 +62,14 @@ The factory wires up eight Starlight plugins automatically:
 | `starlight-mega-menu` | Top navigation mega menu with grid/list layouts |
 | `starlight-videos` | Embed videos in documentation pages |
 | `starlight-image-zoom` | Click-to-zoom on images |
-| `f5xc-docs-theme` (self) | CSS injection, component overrides, route middleware |
+| `@f5xc-salesdemos/docs-theme` (self) | CSS injection, component overrides, route middleware |
 | `starlight-scroll-to-top` | Scroll-to-top button with progress ring |
 | `starlight-heading-badges` | Badge annotations on headings |
 | `starlight-page-actions` | Page action buttons |
 | `starlight-plugin-icons` | Icon support in Starlight |
 | `starlight-llms-txt` | Generates `llms.txt` and `llms-full.txt` for LLM consumption |
 
-These are registered in order inside `config.ts`. The theme plugin (`f5xc-docs-theme`) is itself a Starlight plugin that runs in this list.
+These are registered in order inside `config.ts`. The theme plugin (`@f5xc-salesdemos/docs-theme`) is itself a Starlight plugin that runs in this list.
 
 ## Theme Plugin Hook
 
@@ -88,26 +88,26 @@ The theme plugin is defined in `index.ts` and registered among the bundled plugi
 // index.ts — Starlight plugin entry point
 export default function f5xcDocsTheme(): StarlightPlugin {
   return {
-    name: 'f5xc-docs-theme',
+    name: '@f5xc-salesdemos/docs-theme',
     hooks: {
       'config:setup'({ config, updateConfig, addRouteMiddleware }) {
         addRouteMiddleware({
-          entrypoint: 'f5xc-docs-theme/route-middleware',
+          entrypoint: '@f5xc-salesdemos/docs-theme/route-middleware',
           order: 'pre',
         });
         updateConfig({
           customCss: [
             ...(config.customCss ?? []),
-            'f5xc-docs-theme/fonts/font-face.css',
-            'f5xc-docs-theme/styles/custom.css',
+            '@f5xc-salesdemos/docs-theme/fonts/font-face.css',
+            '@f5xc-salesdemos/docs-theme/styles/custom.css',
           ],
           components: {
             ...config.components,
-            Banner: 'f5xc-docs-theme/components/Banner.astro',
-            EditLink: 'f5xc-docs-theme/components/EditLink.astro',
-            Footer: 'f5xc-docs-theme/components/Footer.astro',
-            SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
-            MarkdownContent: 'f5xc-docs-theme/components/MarkdownContent.astro',
+            Banner: '@f5xc-salesdemos/docs-theme/components/Banner.astro',
+            EditLink: '@f5xc-salesdemos/docs-theme/components/EditLink.astro',
+            Footer: '@f5xc-salesdemos/docs-theme/components/Footer.astro',
+            SiteTitle: '@f5xc-salesdemos/docs-theme/components/SiteTitle.astro',
+            MarkdownContent: '@f5xc-salesdemos/docs-theme/components/MarkdownContent.astro',
           },
         });
       },
@@ -116,7 +116,7 @@ export default function f5xcDocsTheme(): StarlightPlugin {
 }
 ```
 
-All paths use npm package specifiers (e.g., `f5xc-docs-theme/styles/custom.css`) which resolve through the `exports` map in `package.json`.
+All paths use npm package specifiers (e.g., `@f5xc-salesdemos/docs-theme/styles/custom.css`) which resolve through the `exports` map in `package.json`.
 
 ## Other Integrations
 

--- a/docs/build-pipeline.mdx
+++ b/docs/build-pipeline.mdx
@@ -5,7 +5,7 @@ sidebar:
   order: 3
 ---
 
-This page describes how content repositories consume the `f5xc-docs-theme` npm package to produce fully branded documentation sites.
+This page describes how content repositories consume the `@f5xc-salesdemos/docs-theme` npm package to produce fully branded documentation sites.
 
 ## Architecture
 
@@ -21,10 +21,10 @@ This page describes how content repositories consume the `f5xc-docs-theme` npm p
 │   (Docker image)          │
 │                           │
 │  npm install              │
-│  f5xc-docs-theme ─────┐  │
+│  @f5xc-salesdemos/docs-theme ─────┐  │
 │                        ▼  │
 │  node_modules/            │
-│    f5xc-docs-theme/       │
+│    @f5xc-salesdemos/docs-theme/       │
 │      ├── config.ts        │
 │      ├── index.ts         │
 │      ├── fonts/           │
@@ -55,9 +55,9 @@ This page describes how content repositories consume the `f5xc-docs-theme` npm p
        uses: f5xc-salesdemos/docs-control/.github/workflows/github-pages-deploy.yml@main
    ```
 3. **Docker builder runs** — the `f5xc-docs-builder` Docker image already has the theme pre-installed via npm. At build time it:
-   - Copies `astro.config.mjs` and `content.config.ts` from `node_modules/f5xc-docs-theme/` into the Astro project root
+   - Copies `astro.config.mjs` and `content.config.ts` from `node_modules/@f5xc-salesdemos/docs-theme/` into the Astro project root
    - Copies the content repo's `docs/` files into `src/content/docs/`
-4. **Astro build** — Astro reads the config which calls `createF5xcDocsConfig()`. The factory resolves all theme assets through npm package specifiers (e.g., `f5xc-docs-theme/styles/custom.css`)
+4. **Astro build** — Astro reads the config which calls `createF5xcDocsConfig()`. The factory resolves all theme assets through npm package specifiers (e.g., `@f5xc-salesdemos/docs-theme/styles/custom.css`)
 5. **Deploy** — the built static site is deployed to GitHub Pages
 
 ## Content Repo Requirements
@@ -98,15 +98,15 @@ All paths in the theme use npm package specifiers, resolved through the `exports
 
 ```js
 // CSS — resolved from node_modules
-'f5xc-docs-theme/fonts/font-face.css'
-'f5xc-docs-theme/styles/custom.css'
+'@f5xc-salesdemos/docs-theme/fonts/font-face.css'
+'@f5xc-salesdemos/docs-theme/styles/custom.css'
 
 // Components — resolved from node_modules
-'f5xc-docs-theme/components/Footer.astro'
-'f5xc-docs-theme/components/Banner.astro'
+'@f5xc-salesdemos/docs-theme/components/Footer.astro'
+'@f5xc-salesdemos/docs-theme/components/Banner.astro'
 
 // Assets — resolved from node_modules
-'f5xc-docs-theme/assets/github-avatar.png'
+'@f5xc-salesdemos/docs-theme/assets/github-avatar.png'
 ```
 
 There is no `./theme/` directory in the build workspace. The Docker builder installs the theme as a regular npm dependency and Astro resolves all specifiers through `node_modules`.
@@ -119,7 +119,7 @@ Font file paths inside `font-face.css` use `./` (e.g., `url("./neusaNextProWide-
 
 Theme changes propagate through npm package updates:
 
-1. A change is merged to `main` in `f5xc-docs-theme`
+1. A change is merged to `main` in `@f5xc-salesdemos/docs-theme`
 2. The Docker builder image is rebuilt with the updated package
 3. The next time any content repo's workflow runs, it uses the updated builder image
 4. The Astro build picks up the updated fonts, styles, logo, components, and plugins

--- a/docs/code-blocks.mdx
+++ b/docs/code-blocks.mdx
@@ -55,7 +55,7 @@ site:
 
 ```json
 {
-  "name": "f5xc-docs-theme",
+  "name": "@f5xc-salesdemos/docs-theme",
   "version": "1.0.0",
   "type": "module",
   "main": "index.js"
@@ -112,7 +112,7 @@ const config: Config = {
 Terminal-style code blocks (fenced with ` ```bash ` or ` ```sh `) receive an iTerm-inspired window frame with macOS traffic light dots.
 
 ```bash title="Terminal"
-npm install f5xc-docs-theme
+npm install @f5xc-salesdemos/docs-theme
 npx astro build
 npx astro preview
 ```

--- a/docs/components.mdx
+++ b/docs/components.mdx
@@ -9,7 +9,7 @@ sidebar:
 ---
 
 import { Aside, Tabs, TabItem, Steps, Card, CardGrid, Badge, FileTree } from '@astrojs/starlight/components';
-import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 
 ## Asides
 
@@ -117,17 +117,17 @@ These two tab groups share `syncKey="pkg"`. Selecting a tab in one group should 
 <Tabs syncKey="pkg">
   <TabItem label="npm">
     ```bash
-    npm install f5xc-docs-theme
+    npm install @f5xc-salesdemos/docs-theme
     ```
   </TabItem>
   <TabItem label="pnpm">
     ```bash
-    pnpm add f5xc-docs-theme
+    pnpm add @f5xc-salesdemos/docs-theme
     ```
   </TabItem>
   <TabItem label="yarn">
     ```bash
-    yarn add f5xc-docs-theme
+    yarn add @f5xc-salesdemos/docs-theme
     ```
   </TabItem>
 </Tabs>
@@ -226,7 +226,7 @@ These two tab groups share `syncKey="pkg"`. Selecting a tab in one group should 
 The theme provides a `LinkCard` component that works with or without icons. Import it from the theme:
 
 ```mdx
-import LinkCard from 'f5xc-docs-theme/components/LinkCard.astro';
+import LinkCard from '@f5xc-salesdemos/docs-theme/components/LinkCard.astro';
 ```
 
 <CardGrid>

--- a/docs/diagrams/instructions.mdx
+++ b/docs/diagrams/instructions.mdx
@@ -32,14 +32,14 @@ The following icon packs are registered and available in Mermaid diagrams. Icons
 
 | Pack Name | npm Package | Key Icons |
 |-----------|-------------|-----------|
-| `hashicorp-flight` | `@robinmordasiewicz/icons-hashicorp-flight` | `terraform-color`, `consul-color`, `vault-color`, `aws-color`, `azure-color`, `gcp-color`, `kubernetes-color`, `docker-color` |
-| `f5-brand` | `@robinmordasiewicz/icons-f5-brand` | `network-gateway`, `security-firewall`, `security-shield-network`, `cloud-multi`, `hw-server` |
-| `f5xc` | `@robinmordasiewicz/icons-f5xc` | `web-app-and-api-protection`, `bot-defense`, `multi-cloud-app-connect`, `dns-management`, `content-delivery-network` |
-| `carbon` | `@robinmordasiewicz/icons-carbon` | `cloud-services`, `data-base`, `gateway-api`, `virtual-machine`, `load-balancer-global`, `firewall`, `dns-services`, `virtual-private-cloud` |
-| `lucide` | `@robinmordasiewicz/icons-lucide` | `server`, `database`, `shield`, `shield-check`, `globe`, `lock`, `cloud`, `network`, `user` |
-| `mdi` | `@robinmordasiewicz/icons-mdi` | `server`, `database`, `shield`, `cloud`, `lock`, `network`, `dns`, `vpn`, `router` |
-| `phosphor` | `@robinmordasiewicz/icons-phosphor` | `cloud`, `database`, `shield`, `globe`, `lock`, `network` |
-| `tabler` | `@robinmordasiewicz/icons-tabler` | `server`, `database`, `shield`, `cloud`, `lock`, `network`, `route`, `router` |
+| `hashicorp-flight` | `@f5xc-salesdemos/icons-hashicorp-flight` | `terraform-color`, `consul-color`, `vault-color`, `aws-color`, `azure-color`, `gcp-color`, `kubernetes-color`, `docker-color` |
+| `f5-brand` | `@f5xc-salesdemos/icons-f5-brand` | `network-gateway`, `security-firewall`, `security-shield-network`, `cloud-multi`, `hw-server` |
+| `f5xc` | `@f5xc-salesdemos/icons-f5xc` | `web-app-and-api-protection`, `bot-defense`, `multi-cloud-app-connect`, `dns-management`, `content-delivery-network` |
+| `carbon` | `@f5xc-salesdemos/icons-carbon` | `cloud-services`, `data-base`, `gateway-api`, `virtual-machine`, `load-balancer-global`, `firewall`, `dns-services`, `virtual-private-cloud` |
+| `lucide` | `@f5xc-salesdemos/icons-lucide` | `server`, `database`, `shield`, `shield-check`, `globe`, `lock`, `cloud`, `network`, `user` |
+| `mdi` | `@f5xc-salesdemos/icons-mdi` | `server`, `database`, `shield`, `cloud`, `lock`, `network`, `dns`, `vpn`, `router` |
+| `phosphor` | `@f5xc-salesdemos/icons-phosphor` | `cloud`, `database`, `shield`, `globe`, `lock`, `network` |
+| `tabler` | `@f5xc-salesdemos/icons-tabler` | `server`, `database`, `shield`, `cloud`, `lock`, `network`, `route`, `router` |
 
 ## CSS Reference
 

--- a/docs/footer.mdx
+++ b/docs/footer.mdx
@@ -31,7 +31,7 @@ The footer override is registered by the Starlight plugin in `index.ts`. During 
 updateConfig({
   components: {
     ...config.components,
-    Footer: 'f5xc-docs-theme/components/Footer.astro',
+    Footer: '@f5xc-salesdemos/docs-theme/components/Footer.astro',
     // ... other component overrides
   },
 });
@@ -78,7 +78,7 @@ The links are right-aligned in a flex row with a subtle opacity hover effect.
 
 ### Changing a URL
 
-Edit the `href` attribute on the corresponding `<a>` tag in `components/Footer.astro` within the `f5xc-docs-theme` package.
+Edit the `href` attribute on the corresponding `<a>` tag in `components/Footer.astro` within the `@f5xc-salesdemos/docs-theme` package.
 
 ### Adding a Link
 

--- a/docs/logo.mdx
+++ b/docs/logo.mdx
@@ -21,7 +21,7 @@ The theme ships two logo files in the `assets/` directory:
 The default logo is set in the `createF5xcDocsConfig` factory in `config.ts`:
 
 ```ts
-const logo = options.logo || { src: 'f5xc-docs-theme/assets/github-avatar.png' };
+const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/github-avatar.png' };
 ```
 
 If no `logo` option is provided, the GitHub avatar PNG is used. The path is an npm package specifier resolved through the `exports` map in `package.json`.
@@ -33,10 +33,10 @@ If no `logo` option is provided, the GitHub avatar PNG is used. The path is an n
 Pass the `logo` option to `createF5xcDocsConfig`:
 
 ```ts
-import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
+import { createF5xcDocsConfig } from '@f5xc-salesdemos/docs-theme/config';
 
 export default createF5xcDocsConfig({
-  logo: { src: 'f5xc-docs-theme/assets/f5-logo.svg' },
+  logo: { src: '@f5xc-salesdemos/docs-theme/assets/f5-logo.svg' },
 });
 ```
 
@@ -45,7 +45,7 @@ export default createF5xcDocsConfig({
 Place your logo file in the content repo and reference it:
 
 ```ts
-import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
+import { createF5xcDocsConfig } from '@f5xc-salesdemos/docs-theme/config';
 
 export default createF5xcDocsConfig({
   logo: { src: './src/assets/my-logo.svg' },
@@ -57,7 +57,7 @@ export default createF5xcDocsConfig({
 Starlight supports separate logos for light and dark mode:
 
 ```ts
-import { createF5xcDocsConfig } from 'f5xc-docs-theme/config';
+import { createF5xcDocsConfig } from '@f5xc-salesdemos/docs-theme/config';
 
 export default createF5xcDocsConfig({
   logo: {

--- a/docs/style-enhancement-guide.mdx
+++ b/docs/style-enhancement-guide.mdx
@@ -1,6 +1,6 @@
 ---
 title: Style Enhancement Guide
-description: Design system token reference for the f5xc-docs-theme
+description: Design system token reference for the @f5xc-salesdemos/docs-theme
 sidebar:
   order: 12
 ---

--- a/index.ts
+++ b/index.ts
@@ -2,27 +2,27 @@ import type { StarlightPlugin } from '@astrojs/starlight/types';
 
 export default function f5xcDocsTheme(): StarlightPlugin {
   return {
-    name: 'f5xc-docs-theme',
+    name: '@f5xc-salesdemos/docs-theme',
     hooks: {
       'config:setup'({ config, updateConfig, addRouteMiddleware, logger }) {
         addRouteMiddleware({
-          entrypoint: 'f5xc-docs-theme/route-middleware',
+          entrypoint: '@f5xc-salesdemos/docs-theme/route-middleware',
           order: 'pre',
         });
         updateConfig({
           customCss: [
             ...(config.customCss ?? []),
-            'f5xc-docs-theme/fonts/font-face.css',
-            'f5xc-docs-theme/styles/custom.css',
+            '@f5xc-salesdemos/docs-theme/fonts/font-face.css',
+            '@f5xc-salesdemos/docs-theme/styles/custom.css',
           ],
           components: {
             ...config.components,
-            Banner: 'f5xc-docs-theme/components/Banner.astro',
-            EditLink: 'f5xc-docs-theme/components/EditLink.astro',
-            Footer: 'f5xc-docs-theme/components/Footer.astro',
-            SiteTitle: 'f5xc-docs-theme/components/SiteTitle.astro',
+            Banner: '@f5xc-salesdemos/docs-theme/components/Banner.astro',
+            EditLink: '@f5xc-salesdemos/docs-theme/components/EditLink.astro',
+            Footer: '@f5xc-salesdemos/docs-theme/components/Footer.astro',
+            SiteTitle: '@f5xc-salesdemos/docs-theme/components/SiteTitle.astro',
             MarkdownContent: process.env.DOCS_MARKDOWN_CONTENT
-              || 'f5xc-docs-theme/components/MarkdownContent.astro',
+              || '@f5xc-salesdemos/docs-theme/components/MarkdownContent.astro',
           },
         });
         logger.info('F5 XC docs theme loaded');

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "f5xc-docs-theme",
+  "name": "@f5xc-salesdemos/docs-theme",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "f5xc-docs-theme",
+      "name": "@f5xc-salesdemos/docs-theme",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
@@ -25,15 +25,25 @@
       },
       "peerDependencies": {
         "@astrojs/starlight": ">=0.34.0",
+        "@f5xc-salesdemos/icons-f5-brand": "*",
+        "@f5xc-salesdemos/icons-f5xc": "*",
+        "@f5xc-salesdemos/icons-hashicorp-flight": "*",
         "@iconify-json/carbon": "*",
         "@iconify-json/lucide": "*",
         "@iconify-json/mdi": "*",
         "@iconify-json/ph": "*",
-        "@iconify-json/tabler": "*",
-        "@robinmordasiewicz/icons-f5-brand": "*",
-        "@robinmordasiewicz/icons-hashicorp-flight": "*"
+        "@iconify-json/tabler": "*"
       },
       "peerDependenciesMeta": {
+        "@f5xc-salesdemos/icons-f5-brand": {
+          "optional": true
+        },
+        "@f5xc-salesdemos/icons-f5xc": {
+          "optional": true
+        },
+        "@f5xc-salesdemos/icons-hashicorp-flight": {
+          "optional": true
+        },
         "@iconify-json/carbon": {
           "optional": true
         },
@@ -47,12 +57,6 @@
           "optional": true
         },
         "@iconify-json/tabler": {
-          "optional": true
-        },
-        "@robinmordasiewicz/icons-f5-brand": {
-          "optional": true
-        },
-        "@robinmordasiewicz/icons-hashicorp-flight": {
           "optional": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "f5xc-docs-theme",
+  "name": "@f5xc-salesdemos/docs-theme",
   "version": "0.1.0",
   "description": "F5 Distributed Cloud branded Starlight documentation theme",
   "type": "module",
@@ -70,9 +70,9 @@
     "@iconify-json/mdi": "*",
     "@iconify-json/ph": "*",
     "@iconify-json/tabler": "*",
-    "@robinmordasiewicz/icons-f5-brand": "*",
-    "@robinmordasiewicz/icons-f5xc": "*",
-    "@robinmordasiewicz/icons-hashicorp-flight": "*"
+    "@f5xc-salesdemos/icons-f5-brand": "*",
+    "@f5xc-salesdemos/icons-f5xc": "*",
+    "@f5xc-salesdemos/icons-hashicorp-flight": "*"
   },
   "peerDependenciesMeta": {
     "@iconify-json/lucide": { "optional": true },
@@ -80,9 +80,9 @@
     "@iconify-json/mdi": { "optional": true },
     "@iconify-json/ph": { "optional": true },
     "@iconify-json/tabler": { "optional": true },
-    "@robinmordasiewicz/icons-f5-brand": { "optional": true },
-    "@robinmordasiewicz/icons-f5xc": { "optional": true },
-    "@robinmordasiewicz/icons-hashicorp-flight": { "optional": true }
+    "@f5xc-salesdemos/icons-f5-brand": { "optional": true },
+    "@f5xc-salesdemos/icons-f5xc": { "optional": true },
+    "@f5xc-salesdemos/icons-hashicorp-flight": { "optional": true }
   },
   "dependencies": {
     "@astrojs/react": "^4.0.0",

--- a/src/utils/resolve-icon.ts
+++ b/src/utils/resolve-icon.ts
@@ -42,13 +42,13 @@ export function resolveIcon(name: string): string {
       iconData = require('@iconify-json/tabler/icons.json');
       break;
     case 'f5-brand':
-      iconData = require('@robinmordasiewicz/icons-f5-brand/icons.json');
+      iconData = require('@f5xc-salesdemos/icons-f5-brand/icons.json');
       break;
     case 'f5xc':
-      iconData = require('@robinmordasiewicz/icons-f5xc/icons.json');
+      iconData = require('@f5xc-salesdemos/icons-f5xc/icons.json');
       break;
     case 'hashicorp-flight':
-      iconData = require('@robinmordasiewicz/icons-hashicorp-flight/icons.json');
+      iconData = require('@f5xc-salesdemos/icons-hashicorp-flight/icons.json');
       break;
     default:
       throw new Error(


### PR DESCRIPTION
## Summary
- Rename package from `f5xc-docs-theme` to `@f5xc-salesdemos/docs-theme`
- Update all icon package references from `@robinmordasiewicz/icons-*` to `@f5xc-salesdemos/icons-*`
- Updates 16 files: source code, docs, workflow, components

## Test plan
- [ ] Verify CI passes
- [ ] Verify semantic-release publishes `@f5xc-salesdemos/docs-theme` to npm
- [ ] Verify dispatch-downstream triggers docs-builder rebuild

Closes #205

🤖 Generated with [Claude Code](https://claude.com/claude-code)