### PR TITLE
fix: resolve super-linter failures across docs-theme source files

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,2 @@
+[codespell]
+ignore-words-list = aks

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://biomejs.dev/schemas/1.9.4/schema.json",
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single"
+    }
+  },
+  "overrides": [
+    {
+      "include": ["**/*.astro"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noUnusedVariables": "off",
+            "noUnusedImports": "off"
+          }
+        }
+      }
+    }
+  ]
+}

--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -3,103 +3,103 @@ import Icon from './Icon.astro';
 import type { HTMLAttributes } from 'astro/types';
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
-	title: string;
-	description?: string;
-	icon?: string;
+  title: string;
+  description?: string;
+  icon?: string;
 }
 
 const { title, description, icon, ...attributes } = Astro.props;
 ---
 
 <div class:list={['sl-link-card', { 'has-icon': !!icon }]}>
-	{icon && (
-		<span class="card-icon">
-			<Icon name={icon} />
-		</span>
-	)}
-	<span class="sl-flex stack">
-		<a {...attributes}>
-			<span class="title" set:html={title} />
-		</a>
-		{description && <span class="description" set:html={description} />}
-	</span>
-	<Icon name="right-arrow" size="1.333em" class="icon rtl:flip" />
+  {icon && (
+    <span class="card-icon">
+      <Icon name={icon} />
+    </span>
+  )}
+  <span class="sl-flex stack">
+    <a {...attributes}>
+      <span class="title" set:html={title} />
+    </a>
+    {description && <span class="description" set:html={description} />}
+  </span>
+  <Icon name="right-arrow" size="1.333em" class="icon rtl:flip" />
 </div>
 
 <style>
-	.sl-link-card {
-		display: grid;
-		grid-template-columns: 1fr auto;
-		gap: 0.5rem;
-		border: 1px solid var(--sl-color-gray-5);
-		border-radius: 0.5rem;
-		padding: 1rem;
-		box-shadow: var(--f5-shadow-low);
-		position: relative;
-		transition: box-shadow var(--f5-transition-base),
-		            transform var(--f5-transition-base);
-	}
+  .sl-link-card {
+    display: grid;
+    grid-template-columns: 1fr auto;
+    gap: 0.5rem;
+    border: 1px solid var(--sl-color-gray-5);
+    border-radius: 0.5rem;
+    padding: 1rem;
+    box-shadow: var(--f5-shadow-low);
+    position: relative;
+    transition: box-shadow var(--f5-transition-base),
+                transform var(--f5-transition-base);
+  }
 
-	.sl-link-card.has-icon {
-		grid-template-columns: auto 1fr auto;
-	}
+  .sl-link-card.has-icon {
+    grid-template-columns: auto 1fr auto;
+  }
 
-	a {
-		text-decoration: none;
-		line-height: var(--sl-line-height-headings);
-	}
+  a {
+    text-decoration: none;
+    line-height: var(--sl-line-height-headings);
+  }
 
-	/* a11y fix for https://github.com/withastro/starlight/issues/487 */
-	a::before {
-		content: '';
-		position: absolute;
-		inset: 0;
-	}
+  /* a11y fix for https://github.com/withastro/starlight/issues/487 */
+  a::before {
+    content: '';
+    position: absolute;
+    inset: 0;
+  }
 
-	.stack {
-		flex-direction: column;
-		gap: 0.5rem;
-	}
+  .stack {
+    flex-direction: column;
+    gap: 0.5rem;
+  }
 
-	.title {
-		color: var(--sl-color-white);
-		font-weight: 600;
-		font-size: var(--sl-text-lg);
-	}
+  .title {
+    color: var(--sl-color-white);
+    font-weight: 600;
+    font-size: var(--sl-text-lg);
+  }
 
-	.description {
-		color: var(--sl-color-gray-3);
-		line-height: 1.5;
-	}
+  .description {
+    color: var(--sl-color-gray-3);
+    line-height: 1.5;
+  }
 
-	.icon {
-		color: var(--sl-color-gray-3);
-	}
+  .icon {
+    color: var(--sl-color-gray-3);
+  }
 
-	.card-icon {
-		color: var(--sl-color-white);
-		align-self: stretch;
-		position: relative;
-		aspect-ratio: 1;
-		max-height: 3rem;
-	}
+  .card-icon {
+    color: var(--sl-color-white);
+    align-self: stretch;
+    position: relative;
+    aspect-ratio: 1;
+    max-height: 3rem;
+  }
 
-	.card-icon :global(svg) {
-		position: absolute;
-		inset: 0;
-		width: 100%;
-		height: 100%;
-	}
+  .card-icon :global(svg) {
+    position: absolute;
+    inset: 0;
+    width: 100%;
+    height: 100%;
+  }
 
-	/* Hover state */
-	.sl-link-card:hover {
-		background: var(--sl-color-gray-7, var(--sl-color-gray-6));
-		border-color: var(--sl-color-gray-2);
-		box-shadow: var(--f5-shadow-mid);
-		transform: translateY(-1px);
-	}
+  /* Hover state */
+  .sl-link-card:hover {
+    background: var(--sl-color-gray-7, var(--sl-color-gray-6));
+    border-color: var(--sl-color-gray-2);
+    box-shadow: var(--f5-shadow-mid);
+    transform: translateY(-1px);
+  }
 
-	.sl-link-card:hover .icon {
-		color: var(--sl-color-white);
-	}
+  .sl-link-card:hover .icon {
+    color: var(--sl-color-white);
+  }
 </style>

--- a/fonts/font-face.css
+++ b/fonts/font-face.css
@@ -1,5 +1,5 @@
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 300;
   font-style: normal;
   font-display: swap;
@@ -7,7 +7,7 @@
 }
 
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -15,7 +15,7 @@
 }
 
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -23,7 +23,7 @@
 }
 
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 700;
   font-style: normal;
   font-display: swap;
@@ -31,7 +31,7 @@
 }
 
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 400;
   font-style: italic;
   font-display: swap;
@@ -39,7 +39,7 @@
 }
 
 @font-face {
-  font-family: "neusaNextProWide";
+  font-family: neusaNextProWide;
   font-weight: 700;
   font-style: italic;
   font-display: swap;
@@ -47,7 +47,7 @@
 }
 
 @font-face {
-  font-family: "proximaNova";
+  font-family: proximaNova;
   font-weight: 400;
   font-style: normal;
   font-display: swap;
@@ -55,7 +55,7 @@
 }
 
 @font-face {
-  font-family: "proximaNova";
+  font-family: proximaNova;
   font-weight: 500;
   font-style: normal;
   font-display: swap;
@@ -63,7 +63,7 @@
 }
 
 @font-face {
-  font-family: "proximaNova";
+  font-family: proximaNova;
   font-weight: 600;
   font-style: normal;
   font-display: swap;
@@ -71,7 +71,7 @@
 }
 
 @font-face {
-  font-family: "proximaNova";
+  font-family: proximaNova;
   font-weight: 700;
   font-style: normal;
   font-display: swap;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1582,27 +1582,6 @@
         "url": "https://opencollective.com/libvips"
       }
     },
-    "node_modules/@isaacs/balanced-match": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/balanced-match/-/balanced-match-4.0.1.tgz",
-      "integrity": "sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==",
-      "license": "MIT",
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
-    "node_modules/@isaacs/brace-expansion": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/@isaacs/brace-expansion/-/brace-expansion-5.0.1.tgz",
-      "integrity": "sha512-WMz71T1JS624nWj2n2fnYAuPovhv7EUhk69R6i9dsVyzxt5eM3bjwvgk9L+APE1TRscGysAVMANkB0jh0LQZrQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@isaacs/balanced-match": "^4.0.1"
-      },
-      "engines": {
-        "node": "20 || >=22"
-      }
-    },
     "node_modules/@isaacs/cliui": {
       "version": "9.0.0",
       "resolved": "https://registry.npmjs.org/@isaacs/cliui/-/cliui-9.0.0.tgz",
@@ -3436,6 +3415,15 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/balanced-match": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-4.0.3.tgz",
+      "integrity": "sha512-1pHv8LX9CpKut1Zp4EXey7Z8OfH11ONNH6Dhi2WDUt31VVZFXZzKwXcysBgqSumFCmR+0dqjMK5v5JiFHzi0+g==",
+      "license": "MIT",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/base-64": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/base-64/-/base-64-1.0.0.tgz",
@@ -3514,6 +3502,18 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.2.tgz",
+      "integrity": "sha512-Pdk8c9poy+YhOgVWw1JNN22/HcivgKWwpxKq04M/jTmHyCZn12WPJebZxdjSa5TmBqISrUSgNYU3eRORljfCCw==",
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^4.0.2"
+      },
+      "engines": {
+        "node": "20 || >=22"
       }
     },
     "node_modules/braces": {
@@ -4002,9 +4002,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.2",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.2.tgz",
-      "integrity": "sha512-nPRkjWzzDQlsejL1WVifk5rvcFi/y1onBRxjaFMjZeR9mFpqu2gmAZ9xUB9/IEanEP/vBtGeGganC/GO1fmufg==",
+      "version": "5.6.3",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
+      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
       "license": "MIT"
     },
     "node_modules/devlop": {
@@ -6442,15 +6442,15 @@
       }
     },
     "node_modules/minimatch": {
-      "version": "10.1.2",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.1.2.tgz",
-      "integrity": "sha512-fu656aJ0n2kcXwsnwnv9g24tkU5uSmOlTjd6WyyaKm2Z+h1qmY6bAjrcaIxF/BslFqbZ8UBtbJi7KgQOZD2PTw==",
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-10.2.2.tgz",
+      "integrity": "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
-        "@isaacs/brace-expansion": "^5.0.1"
+        "brace-expansion": "^5.0.2"
       },
       "engines": {
-        "node": "20 || >=22"
+        "node": "18 || 20 || >=22"
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -35,16 +35,16 @@
   --f5-bay-2: #66afd7;
   --f5-bay-3: #005c8d;
   --f5-bay-4: #003d5f;
-  --f5-white: #ffffff;
+  --f5-white: #fff;
   --f5-white-1: #faf9f7;
   --f5-white-2: #f5f5f5;
   --f5-white-3: #e6e6e6;
-  --f5-white-4: #cccccc;
-  --f5-black: #000000;
-  --f5-black-1: #999999;
-  --f5-black-2: #666666;
+  --f5-white-4: #ccc;
+  --f5-black: #000;
+  --f5-black-1: #999;
+  --f5-black-2: #666;
   --f5-black-3: #343434;
-  --f5-black-4: #222222;
+  --f5-black-4: #222;
 }
 
 /* ===== F5 XC Multi-Color Icon Variables ===== */
@@ -115,7 +115,7 @@
   /* Borders — dark mode (alpha-transparent) */
   --f5-border-faint: #f5f5f51a;
   --f5-border-default: #f5f5f533;
-  --f5-border-strong: #cccccc66;
+  --f5-border-strong: #ccc6;
 
   /* Surfaces — dark mode */
   --f5-surface-hover: var(--f5-black-3);
@@ -173,7 +173,7 @@
   /* Borders — light mode */
   --f5-border-faint: #3434341a;
   --f5-border-default: #34343433;
-  --f5-border-strong: #22222266;
+  --f5-border-strong: #2226;
 
   /* Surfaces — light mode */
   --f5-surface-hover: var(--f5-white-2);
@@ -412,8 +412,8 @@ h4, h5, h6 {
   font-family: var(--sl-font);
 }
 
-.swatch-color.text-light { color: #ffffff; }
-.swatch-color.text-dark { color: #000000; }
+.swatch-color.text-light { color: #fff; }
+.swatch-color.text-dark { color: #000; }
 
 .swatch-label {
   padding: 0.5rem;
@@ -549,13 +549,13 @@ body {
 }
 
 /* ===== Phase 4: Button Component System ===== */
-.btn-primary {
+.btn-primary,
+.btn-secondary,
+.btn-tertiary,
+.btn-critical {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
-  background: var(--f5-red);
-  color: var(--f5-white);
-  border: none;
   border-radius: var(--f5-radius-sm);
   padding: 0.625rem 1rem;
   min-height: 2.5rem;
@@ -564,6 +564,12 @@ body {
   font-family: var(--sl-font);
   cursor: pointer;
   text-decoration: none;
+}
+
+.btn-primary {
+  background: var(--f5-red);
+  color: var(--f5-white);
+  border: none;
   transition: background-color var(--f5-transition-fast),
               box-shadow var(--f5-transition-fast);
 }
@@ -575,20 +581,9 @@ body {
 }
 
 .btn-secondary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
   background: transparent;
   color: var(--sl-color-gray-2);
   border: 1px solid var(--f5-border-default);
-  border-radius: var(--f5-radius-sm);
-  padding: 0.625rem 1rem;
-  min-height: 2.5rem;
-  font-weight: 500;
-  font-size: 0.875rem;
-  font-family: var(--sl-font);
-  cursor: pointer;
-  text-decoration: none;
   transition: background-color var(--f5-transition-fast),
               border-color var(--f5-transition-fast);
 }
@@ -599,20 +594,9 @@ body {
 }
 
 .btn-tertiary {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
   background: transparent;
   color: var(--sl-color-accent);
   border: none;
-  border-radius: var(--f5-radius-sm);
-  padding: 0.625rem 1rem;
-  min-height: 2.5rem;
-  font-weight: 500;
-  font-size: 0.875rem;
-  font-family: var(--sl-font);
-  cursor: pointer;
-  text-decoration: none;
   transition: background-color var(--f5-transition-fast);
 }
 .btn-tertiary:hover {
@@ -624,20 +608,9 @@ body {
 .btn-lg { padding: 0.75rem 1.5rem; font-size: 1rem; min-height: 3rem; }
 
 .btn-critical {
-  display: inline-flex;
-  align-items: center;
-  gap: 0.5rem;
   background: var(--f5-red-3);
   color: var(--f5-white);
   border: none;
-  border-radius: var(--f5-radius-sm);
-  padding: 0.625rem 1rem;
-  min-height: 2.5rem;
-  font-weight: 500;
-  font-size: 0.875rem;
-  font-family: var(--sl-font);
-  cursor: pointer;
-  text-decoration: none;
   transition: background-color var(--f5-transition-fast),
               box-shadow var(--f5-transition-fast);
 }
@@ -668,7 +641,7 @@ body {
   background: linear-gradient(180deg, #faf9f7 0%, #f5f5f5 100%);
 }
 :root:not([data-theme='light']) .hero-gradient-faint {
-  background: linear-gradient(180deg, #222222 0%, #000000 100%);
+  background: linear-gradient(180deg, #222 0%, #000 100%);
 }
 
 .hero-fade {


### PR DESCRIPTION
## Summary

- Add `biome.json` with single-quote style and disable false-positive unused import/variable rules for `.astro` files (fixes BIOME_FORMAT + BIOME_LINT)
- Add `.codespellrc` to ignore "AKS" abbreviation (fixes SPELL_CODESPELL)
- Convert tabs to spaces in `LinkCard.astro` (fixes EDITORCONFIG)
- Remove quotes from `font-family` values in `font-face.css` (fixes CSS/stylelint)
- Shorten hex color values to shorthand notation in `custom.css` (fixes CSS/stylelint)
- Deduplicate button CSS by extracting shared properties into grouped selector (fixes JSCPD)
- Update `devalue` 5.6.2→5.6.3 and `minimatch` via `npm audit fix` (fixes TRIVY)

## Out of Scope

ZIZMOR findings are in managed files synced from `docs-control` — fixes must go to that repo.

## Test plan

- [ ] Verify super-linter CI passes on this PR
- [ ] Verify no visual regressions in buttons, breadcrumbs, fonts, color swatches, icon cards
- [ ] Confirm `npm audit` shows 0 vulnerabilities

Closes #209

🤖 Generated with [Claude Code](https://claude.com/claude-code)