### PR TITLE
fix: sort imports per biome organizeImports rules

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -1,6 +1,6 @@
 ---
-import Icon from './Icon.astro';
 import type { HTMLAttributes } from 'astro/types';
+import Icon from './Icon.astro';
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
   title: string;

--- a/components/MarkdownContent.astro
+++ b/components/MarkdownContent.astro
@@ -1,6 +1,6 @@
 ---
-import StarlightVideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro';
 import ImageZoom from 'starlight-image-zoom/components/ImageZoom.astro';
+import StarlightVideosMarkdownContent from 'starlight-videos/components/MarkdownContent.astro';
 ---
 
 <ImageZoom />

--- a/components/SiteTitle.astro
+++ b/components/SiteTitle.astro
@@ -1,6 +1,6 @@
 ---
-import { logos } from 'virtual:starlight/user-images';
 import config from 'virtual:starlight/user-config';
+import { logos } from 'virtual:starlight/user-images';
 
 const docsHome = process.env.DOCS_HOME || 'https://f5xc-salesdemos.github.io/docs/';
 const { siteTitle } = Astro.locals.starlightRoute;

--- a/config.ts
+++ b/config.ts
@@ -1,18 +1,18 @@
-import { defineConfig } from 'astro/config';
-import type { AstroIntegration } from 'astro';
-import starlight from '@astrojs/starlight';
 import react from '@astrojs/react';
-import f5xcDocsTheme from './index.ts';
-import remarkMermaid from './src/plugins/remark-mermaid.mjs';
-import starlightScrollToTop from 'starlight-scroll-to-top';
-import starlightImageZoom from 'starlight-image-zoom';
+import starlight from '@astrojs/starlight';
+import type { StarlightPlugin } from '@astrojs/starlight/types';
+import type { AstroIntegration } from 'astro';
+import { defineConfig } from 'astro/config';
 import starlightHeadingBadges from 'starlight-heading-badges';
-import starlightVideosPlugin from 'starlight-videos';
-import starlightPageActions from 'starlight-page-actions';
-import { starlightIconsPlugin } from 'starlight-plugin-icons';
+import starlightImageZoom from 'starlight-image-zoom';
 import starlightLlmsTxt from 'starlight-llms-txt';
 import starlightMegaMenu from 'starlight-mega-menu';
-import type { StarlightPlugin } from '@astrojs/starlight/types';
+import starlightPageActions from 'starlight-page-actions';
+import { starlightIconsPlugin } from 'starlight-plugin-icons';
+import starlightScrollToTop from 'starlight-scroll-to-top';
+import starlightVideosPlugin from 'starlight-videos';
+import f5xcDocsTheme from './index.ts';
+import remarkMermaid from './src/plugins/remark-mermaid.mjs';
 import { resolveIcon } from './src/utils/resolve-icon.ts';
 
 interface MegaMenuItem {

--- a/route-middleware.ts
+++ b/route-middleware.ts
@@ -1,5 +1,5 @@
-import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 import type { StarlightRouteData } from '@astrojs/starlight/route-data';
+import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
 
 type SidebarEntry = StarlightRouteData['sidebar'][number];
 

--- a/tests/visual/pages.spec.ts
+++ b/tests/visual/pages.spec.ts
@@ -1,4 +1,4 @@
-import { test, expect } from '@playwright/test';
+import { expect, test } from '@playwright/test';
 
 const pages = [
   { name: 'home', path: '/' },


### PR DESCRIPTION
## Summary
- Auto-fix biome `organizeImports` warnings in 6 files by running `biome check --write .`
- Import statements are now sorted alphabetically with type imports before value imports
- Closes #224

## Changes
| File | Change |
|------|--------|
| `components/LinkCard.astro` | Type import before local import |
| `components/MarkdownContent.astro` | Alphabetize imports |
| `components/SiteTitle.astro` | Alphabetize imports |
| `config.ts` | Reorder all imports alphabetically |
| `route-middleware.ts` | Type import before value import |
| `tests/visual/pages.spec.ts` | Alphabetize named exports |

## Test plan
- [ ] `npx @biomejs/biome check .` passes with no fixes
- [ ] `npx @biomejs/biome format .` passes with no fixes
- [ ] Super-linter CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)