### PR TITLE
feat: add federated search across all documentation sites

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -56,6 +56,7 @@ export interface F5xcDocsConfigOptions {
   megaMenuItems?: MegaMenuItem[];
   head?: HeadEntry[];
   logo?: { src: string } | { light: string; dark: string };
+  federatedSearch?: boolean;
 }
 
 const defaultMegaMenuItems: MegaMenuItem[] = [
@@ -316,6 +317,27 @@ mermaid.initialize({
   },
 ];
 
+const federatedSearchSites = [
+  { repo: 'docs-builder', label: 'Docs Builder' },
+  { repo: 'docs-theme', label: 'Docs Theme' },
+  { repo: 'docs', label: 'F5 XC Docs' },
+  { repo: 'administration', label: 'Administration' },
+  { repo: 'nginx', label: 'NGINX' },
+  { repo: 'observability', label: 'Observability' },
+  { repo: 'was', label: 'Web App Scanning' },
+  { repo: 'mcn', label: 'Multi-Cloud Networking' },
+  { repo: 'dns', label: 'DNS' },
+  { repo: 'cdn', label: 'CDN' },
+  { repo: 'bot-standard', label: 'Bot Standard' },
+  { repo: 'bot-advanced', label: 'Bot Advanced' },
+  { repo: 'ddos', label: 'DDoS' },
+  { repo: 'waf', label: 'WAF' },
+  { repo: 'api-protection', label: 'API Security' },
+  { repo: 'api-mcp', label: 'API MCP' },
+  { repo: 'csd', label: 'Client-Side Defense' },
+  { repo: 'docs-icons', label: 'Docs Icons' },
+];
+
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   const site = options.site || process.env.DOCS_SITE || 'https://f5xc-salesdemos.github.io';
   const base = options.base || process.env.DOCS_BASE || '/';
@@ -329,6 +351,16 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/f5-distributed-cloud.svg' };
   const additionalRemarkPlugins = options.additionalRemarkPlugins || [];
   const additionalIntegrations = options.additionalIntegrations || [];
+
+  const federatedSearch = options.federatedSearch !== false;
+  const normalizedBase = base.replace(/\/+$/, '');
+  const mergeIndex = federatedSearch
+    ? federatedSearchSites
+        .filter((s) => `/${s.repo}` !== normalizedBase)
+        .map((s) => ({
+          bundlePath: `${site}/${s.repo}/pagefind/`,
+        }))
+    : undefined;
 
   const starlightPlugins: StarlightPlugin[] = [
     starlightMegaMenu({ items: megaMenuItems as Parameters<typeof starlightMegaMenu>[0]['items'] }),
@@ -367,6 +399,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
         plugins: starlightPlugins,
         head: head as Parameters<typeof starlight>[0]['head'],
         logo: logo as Parameters<typeof starlight>[0]['logo'],
+        ...(mergeIndex && mergeIndex.length > 0 ? { pagefind: { mergeIndex } } : {}),
         ...(githubRepository
           ? {
               editLink: {


### PR DESCRIPTION
## Summary

- Add federated search using Starlight's native `pagefind.mergeIndex` to search across all 18 documentation sites from any single site's search bar
- Each site's Pagefind index is fetched at search time from the other sites' GitHub Pages (same-origin, no CORS issues)
- The current site is automatically excluded from the merge list to avoid re-fetching its own index
- Sites can opt out by passing `federatedSearch: false` in their config options

## Changes

- `config.ts`: Add `federatedSearchSites` array listing all 18 documentation site repos
- `config.ts`: Add `federatedSearch?: boolean` property to `F5xcDocsConfigOptions` interface
- `config.ts`: Build `mergeIndex` from the site list, filtering out the current site
- `config.ts`: Pass `pagefind: { mergeIndex }` to the `starlight()` configuration

## How it works

1. User opens search (Ctrl+K / Cmd+K) on any documentation site
2. Pagefind loads the local index plus metadata from all 17 other sites (~300-500KB one-time)
3. User types a query — Pagefind searches all 18 indexes in parallel
4. Results display in the standard Starlight search modal, interlinked by relevance
5. Clicking a result from another site navigates correctly (all sites share `f5xc-salesdemos.github.io`)

## Test plan

- [ ] Verify `config.ts` passes biome lint checks
- [ ] After propagation, open any content site and search for a term unique to a different site
- [ ] Verify search results from other sites appear with correct links
- [ ] Confirm browser DevTools Network tab shows requests to multiple `/pagefind/` endpoints
- [ ] Verify a site with `federatedSearch: false` only searches its own index

Closes #234

🤖 Generated with [Claude Code](https://claude.com/claude-code)