### PR TITLE
feat: add Terraform Provider to mega-menu Platform tab

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -214,6 +214,17 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
             },
           ],
         },
+        {
+          title: 'Automation',
+          items: [
+            {
+              label: 'Terraform Provider',
+              description: 'F5 XC Terraform provider',
+              href: 'https://f5xc-salesdemos.github.io/terraform-provider-f5xc/',
+              icon: resolveIcon('hashicorp-flight:terraform-color'),
+            },
+          ],
+        },
       ],
       footer: {
         label: 'GitHub Organization',


### PR DESCRIPTION
## Summary
- Add "Automation" category to the Platform mega-menu tab in `config.ts`
- Include Terraform Provider entry with `hashicorp-flight:terraform-color` icon
- Does NOT add to `federatedSearchSites` (pending Starlight migration of terraform docs)

## Test plan
- [ ] Verify mega-menu renders with the new Automation category under Platform
- [ ] Confirm the Terraform Provider link navigates to the correct URL
- [ ] Check the icon resolves correctly

Closes #253

🤖 Generated with [Claude Code](https://claude.com/claude-code)