### PR TITLE
fix: remove JSX comment that breaks Astro compiler in Icon.astro

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -87,8 +87,7 @@ const inlineStyle = styleParts.length ? styleParts.join('; ') : undefined;
     set:html={svgBody}
   /></>
 ) : (
-  {/* @ts-expect-error Custom icon wrapper passes through string name */}
-  <StarlightIcon name={name} label={label} color={color} size={size} class={className} />
+  <StarlightIcon name={name as any} label={label} color={color} size={size} class={className} />
 )}
 
 <style>


### PR DESCRIPTION
## Summary

Removes a JSX comment in `components/Icon.astro` that breaks the Astro compiler, causing all downstream content repository docs builds to fail.

## Related Issue

Closes #255

## What type of PR is this?

- [x] Bug fix

## Changes

The ternary expression's `else` branch (line 89-91) contained:

```astro
) : (
  {/* @ts-expect-error Custom icon wrapper passes through string name */}
  <StarlightIcon name={name} ... />
)}
```

The `{/* ... */}` JSX comment inside the ternary's parenthesized false branch causes esbuild to emit invalid JavaScript in the generated `$$render` function, producing:

```
Expected ")" but found "$$render"
  Location: /app/node_modules/@f5xc-salesdemos/docs-theme/components/Icon.astro:108:2
```

**Fix**: Remove the JSX comment and use `as any` inline cast on the `name` prop to suppress the type mismatch (standard Astro pattern for component prop overrides).

## Verification

After merge, semantic-release will publish a new npm version → triggers docs-builder rebuild → triggers content repo rebuilds. The `docs` repo's GitHub Pages Deploy workflow should succeed (last 5 runs all failed with this error).