### PR TITLE
feat: add Dev Container to mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -212,6 +212,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/docs-icons/',
               icon: resolveIcon('f5xc:distributed-apps'),
             },
+            {
+              label: 'Dev Container',
+              description: 'Isolated development environment',
+              href: 'https://f5xc-salesdemos.github.io/devcontainer/',
+              icon: resolveIcon('hashicorp-flight:docker-color'),
+            },
           ],
         },
         {
@@ -347,6 +353,7 @@ const federatedSearchSites = [
   { repo: 'api-mcp', label: 'API MCP' },
   { repo: 'csd', label: 'Client-Side Defense' },
   { repo: 'docs-icons', label: 'Docs Icons' },
+  { repo: 'devcontainer', label: 'Dev Container' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary

Add the devcontainer docs site to the Platform mega menu and federated search.

## Changes

- `config.ts` — Add Dev Container entry to mega menu under Platform → Documentation Tools
  - Uses `hashicorp-flight:docker-color` icon (Docker whale)
  - Links to `https://f5xc-salesdemos.github.io/devcontainer/`
- `config.ts` — Add `{ repo: 'devcontainer', label: 'Dev Container' }` to `federatedSearchSites`

## Impact

This is a `feat:` commit that will trigger semantic-release → npm publish → docs-builder rebuild → all content repos rebuild with updated navigation.

## Testing

- Mega menu shows Dev Container under Platform → Documentation Tools
- Federated search includes devcontainer pagefind index

Closes #266