### PR TITLE
feat: add consistent styling to content screenshots

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -239,6 +239,21 @@ html .mermaid-container svg {
   background: transparent;
 }
 
+/* ===== Content Image Styling (screenshots) ===== */
+.sl-markdown-content > p > img,
+.sl-markdown-content > img {
+  border: 1px solid var(--f5-border-default);
+  border-radius: var(--f5-radius-lg);
+  box-shadow: var(--f5-shadow-mid);
+  margin-block: 0.5rem;
+  transition: box-shadow var(--f5-transition-base);
+}
+
+.sl-markdown-content > p > img:hover,
+.sl-markdown-content > img:hover {
+  box-shadow: var(--f5-shadow-high);
+}
+
 .starlight-aside {
   border-radius: var(--f5-radius-md);
   box-shadow: var(--f5-shadow-low);


### PR DESCRIPTION
## Summary

- Add CSS rules to `styles/custom.css` that style content images (screenshots) with border, rounded corners, drop shadow, and hover elevation
- Uses existing F5 design tokens (`--f5-border-default`, `--f5-radius-lg`, `--f5-shadow-mid`, `--f5-shadow-high`, `--f5-transition-base`)
- Scoped to `.sl-markdown-content > p > img` and `.sl-markdown-content > img` to exclude nav logos, icon cards, mega menu icons, and zoomed overlays

## What changed

15 lines added after the mermaid-container section in `styles/custom.css`.

## What is NOT affected

- Nav logo, icon cards, mega menu icons, sidebar icons (outside `.sl-markdown-content`)
- Mermaid diagrams (SVG inside `.mermaid-container`, not `<img>`)
- Zoomed/lightbox image (cloned to `<body>` by medium-zoom, outside scoped selector)

## Test plan

- [ ] Run local dev server with a content repo containing screenshots
- [ ] Confirm screenshots have rounded corners, thin border, and drop shadow
- [ ] Confirm hover elevates shadow
- [ ] Confirm click-to-zoom still works and zoomed image has no frame
- [ ] Toggle dark/light mode — border and shadow adapt
- [ ] Check icon cards, logos, and nav images are unaffected

Closes #269

🤖 Generated with [Claude Code](https://claude.com/claude-code)