### PR TITLE
fix: screenshot styles not applied inside lists/steps

### DIFF
--- a/styles/custom.css
+++ b/styles/custom.css
@@ -240,14 +240,11 @@ html .mermaid-container svg {
 }
 
 /* ===== Content Image Styling (screenshots) ===== */
-/* starlight-image-zoom wraps <img> in a <starlight-image-zoom-zoomable>
-  custom element, so the actual DOM path from markdown ![](url) is:
-  .sl-markdown-content > p > starlight-image-zoom-zoomable > img
-  We target both wrapped and unwrapped images for resilience. */
-.sl-markdown-content > p > img,
-.sl-markdown-content > img,
-.sl-markdown-content > p > starlight-image-zoom-zoomable > img,
-.sl-markdown-content > starlight-image-zoom-zoomable > img {
+/* Use descendant selector from .sl-markdown-content so images inside
+  lists, steps, blockquotes, and asides are also styled.
+  Keep p > img to avoid styling inline icons in text spans. */
+.sl-markdown-content p > img,
+.sl-markdown-content p > starlight-image-zoom-zoomable > img {
   border: 1px solid var(--f5-border-default);
   border-radius: var(--f5-radius-lg);
   box-shadow: var(--f5-shadow-mid);
@@ -255,10 +252,8 @@ html .mermaid-container svg {
   transition: box-shadow var(--f5-transition-base);
 }
 
-.sl-markdown-content > p > img:hover,
-.sl-markdown-content > img:hover,
-.sl-markdown-content > p > starlight-image-zoom-zoomable > img:hover,
-.sl-markdown-content > starlight-image-zoom-zoomable > img:hover {
+.sl-markdown-content p > img:hover,
+.sl-markdown-content p > starlight-image-zoom-zoomable > img:hover {
   box-shadow: var(--f5-shadow-high);
 }
 


### PR DESCRIPTION
## Summary

Screenshot border/shadow styles were not applied to images inside ordered lists, steps, blockquotes, or asides because selectors used the direct child combinator (`>`) from `.sl-markdown-content`.

## Related Issue

Closes #275

## Changes

- Replaced `.sl-markdown-content > p > img` with `.sl-markdown-content p > img` (descendant combinator)
- Consolidated 4 selectors to 2 per block — covers both wrapped (`starlight-image-zoom-zoomable`) and unwrapped images at any nesting depth
- Kept `p > img` direct child to exclude inline icons in text spans

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions