### PR TITLE
fix: resolve devalue prototype pollution vulnerability

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4158,9 +4158,9 @@
       }
     },
     "node_modules/devalue": {
-      "version": "5.6.3",
-      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.3.tgz",
-      "integrity": "sha512-nc7XjUU/2Lb+SvEFVGcWLiKkzfw8+qHI7zn8WYXKkLMgfGSHbgCEaR6bJpev8Cm6Rmrb19Gfd/tZvGqx9is3wg==",
+      "version": "5.6.4",
+      "resolved": "https://registry.npmjs.org/devalue/-/devalue-5.6.4.tgz",
+      "integrity": "sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==",
       "license": "MIT",
       "peer": true
     },


### PR DESCRIPTION
## Summary

- Updates `devalue` from 5.6.3 to 5.6.4 to fix CVE-2026-30226 (prototype pollution in `devalue.parse` and `devalue.unflatten`)
- Transitive dependency via `@astrojs/starlight` → `astro` → `devalue`
- Resolves TRIVY scan failure in CI

## Test plan

- [ ] TRIVY check passes in CI
- [ ] No regressions in other linter checks

Closes #279

🤖 Generated with [Claude Code](https://claude.com/claude-code)