### PR TITLE
feat: add click-to-zoom to Screenshot component

### DIFF
--- a/components/Screenshot.astro
+++ b/components/Screenshot.astro
@@ -1,4 +1,6 @@
 ---
+import Zoom from 'starlight-image-zoom/components/Zoom.astro';
+
 interface Props {
   light?: string;
   dark?: string;
@@ -19,11 +21,11 @@ const hasBoth = lightSrc && darkSrc;
 
 {hasBoth ? (
   <div class="screenshot-pair">
-    <img src={lightSrc} alt={alt} width={width} height={height} class="screenshot-light" />
-    <img src={darkSrc} alt={alt} width={width} height={height} class="screenshot-dark" />
+    <Zoom label={alt}><img src={lightSrc} alt={alt} width={width} height={height} class="screenshot-light" /></Zoom>
+    <Zoom label={alt}><img src={darkSrc} alt={alt} width={width} height={height} class="screenshot-dark" /></Zoom>
   </div>
 ) : (
   <div class="screenshot-pair">
-    <img src={lightSrc || darkSrc} alt={alt} width={width} height={height} />
+    <Zoom label={alt}><img src={lightSrc || darkSrc} alt={alt} width={width} height={height} /></Zoom>
   </div>
 )}


### PR DESCRIPTION
## Summary

Wrap Screenshot `<img>` elements in the `starlight-image-zoom` `Zoom` component so screenshot images support click-to-zoom, matching the behavior of regular Markdown images.

## Related Issue

Closes #285

## Changes

- Import `Zoom` from `starlight-image-zoom/components/Zoom.astro`
- Wrap each `<img>` in `<Zoom label={alt}>...</Zoom>` for both dual-mode and single-image branches
- No CSS changes needed — existing selectors in `custom.css` already handle `starlight-image-zoom-zoomable` inside `.screenshot-pair`

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions

🤖 Generated with [Claude Code](https://claude.com/claude-code)