### PR TITLE
fix: use declared package export for Zoom component import

### DIFF
--- a/components/Screenshot.astro
+++ b/components/Screenshot.astro
@@ -1,5 +1,5 @@
 ---
-import Zoom from 'starlight-image-zoom/components/Zoom.astro';
+import { Zoom } from 'starlight-image-zoom/components';
 
 interface Props {
   light?: string;


### PR DESCRIPTION
## Summary

Fix the Screenshot component build failure by using the correct package export path for the Zoom component.

## Related Issue

Closes #287

## Changes

- Changed import in `Screenshot.astro` from `import Zoom from 'starlight-image-zoom/components/Zoom.astro'` (not in exports map) to `import { Zoom } from 'starlight-image-zoom/components'` (declared export)
- This fixes the `Missing "./components/Zoom.astro" specifier` build error from PR #286

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions