### PR TITLE
Add marketplace to AI mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -253,6 +253,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/api-mcp/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
+            {
+              label: 'Marketplace',
+              description: 'AI-powered marketplace for F5 XC',
+              href: 'https://f5xc-salesdemos.github.io/marketplace/',
+              icon: resolveIcon('f5xc:ai_assistant_logo'),
+            },
           ],
         },
       ],
@@ -354,6 +360,7 @@ const federatedSearchSites = [
   { repo: 'csd', label: 'Client-Side Defense' },
   { repo: 'docs-icons', label: 'Docs Icons' },
   { repo: 'devcontainer', label: 'Dev Container' },
+  { repo: 'marketplace', label: 'Marketplace' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary
- Adds Marketplace entry to the AI Tools section of the mega menu with `f5xc:ai_assistant_logo` icon
- Adds marketplace to the federated search sites list

## Test plan
- [ ] Verify mega menu shows Marketplace under AI Tools
- [ ] Verify federated search includes marketplace results

Closes #289

🤖 Generated with [Claude Code](https://claude.com/claude-code)