### PR TITLE
feat: add claude-code-proxy to mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -259,6 +259,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
+            {
+              label: 'Claude Code Proxy',
+              description: 'Claude API to OpenAI proxy',
+              href: 'https://f5xc-salesdemos.github.io/claude-code-proxy/',
+              icon: resolveIcon('f5xc:ai_assistant_logo'),
+            },
           ],
         },
       ],
@@ -361,6 +367,7 @@ const federatedSearchSites = [
   { repo: 'docs-icons', label: 'Docs Icons' },
   { repo: 'devcontainer', label: 'Dev Container' },
   { repo: 'marketplace', label: 'Marketplace' },
+  { repo: 'claude-code-proxy', label: 'Claude Code Proxy' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary

Add Claude Code Proxy to the docs-theme mega menu and federated search configuration.

## Related Issue

Closes #291

## Changes

- Added Claude Code Proxy entry to the AI > AI Tools mega menu category (after Marketplace)
- Added `claude-code-proxy` to the `federatedSearchSites` array for cross-site search

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally
- [x] Follows project conventions