### PR TITLE
feat: require Astro 6 and Starlight 0.38+ as peer dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,3 +34,10 @@ updates:
         update-types:
           - "minor"
           - "patch"
+        exclude-patterns:
+          - "astro"
+          - "@astrojs/*"
+      astro-ecosystem:
+        patterns:
+          - "astro"
+          - "@astrojs/*"

--- a/package.json
+++ b/package.json
@@ -65,7 +65,8 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "peerDependencies": {
-    "@astrojs/starlight": ">=0.34.0",
+    "astro": ">=6.0.0",
+    "@astrojs/starlight": ">=0.38.0",
     "@iconify-json/lucide": "*",
     "@iconify-json/carbon": "*",
     "@iconify-json/mdi": "*",


### PR DESCRIPTION
## Summary
- Add `astro: ">=6.0.0"` peer dependency to make the Astro 6 requirement explicit
- Bump `@astrojs/starlight` peer from `>=0.34.0` to `>=0.38.0` (Starlight 0.38 dropped Astro 5 support)
- Separate Astro ecosystem packages in dependabot grouping to prevent future silent version mismatches

Closes #299

## Context
All content repo builds are failing because Dependabot bumped Starlight to 0.38.1 in docs-builder without also bumping Astro to 6.x. The `--legacy-peer-deps` flag silently installed the incompatible pairing. Tightening peer deps here will surface such mismatches earlier.

Companion PR: f5xc-salesdemos/docs-builder#201

## Test plan
- [ ] Semantic release publishes a new minor version
- [ ] Dispatch to docs-builder triggers successfully
- [ ] No breaking changes — theme source uses stable Starlight APIs only

🤖 Generated with [Claude Code](https://claude.com/claude-code)