### PR TITLE
fix: update astro to 6.0.5 in lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@playwright/test": "^1.50.0"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.34.0",
+        "@astrojs/starlight": ">=0.38.0",
         "@f5xc-salesdemos/icons-f5-brand": "*",
         "@f5xc-salesdemos/icons-f5xc": "*",
         "@f5xc-salesdemos/icons-hashicorp-flight": "*",
@@ -32,7 +32,8 @@
         "@iconify-json/lucide": "*",
         "@iconify-json/mdi": "*",
         "@iconify-json/ph": "*",
-        "@iconify-json/tabler": "*"
+        "@iconify-json/tabler": "*",
+        "astro": ">=6.0.0"
       },
       "peerDependenciesMeta": {
         "@f5xc-salesdemos/icons-f5-brand": {
@@ -3460,9 +3461,9 @@
       }
     },
     "node_modules/astro": {
-      "version": "6.0.4",
-      "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.4.tgz",
-      "integrity": "sha512-1piLJCPTL/x7AMO2cjVFSTFyRqKuC3W8sSEySCt1aJio+p/wGs5H3K+Xr/rE9ftKtknLUtjxCqCE7/0NsXfGpQ==",
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/astro/-/astro-6.0.5.tgz",
+      "integrity": "sha512-JnLCwaoCaRXIHuIB8yNztJrd7M3hXrHUMAoQmeXtEBKxRu/738REhaCZ1lapjrS9HlpHsWTu3JUXTERB/0PA7g==",
       "license": "MIT",
       "peer": true,
       "dependencies": {


### PR DESCRIPTION
## Summary
- Update `astro` from 6.0.4 to 6.0.5 in `package-lock.json`

Closes #301

## Test plan
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)