### PR TITLE
chore: remove claude-code-proxy references

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -259,12 +259,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
-            {
-              label: 'Claude Code Proxy',
-              description: 'Claude API to OpenAI proxy',
-              href: 'https://f5xc-salesdemos.github.io/claude-code-proxy/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
           ],
         },
       ],
@@ -367,7 +361,6 @@ const federatedSearchSites = [
   { repo: 'docs-icons', label: 'Docs Icons' },
   { repo: 'devcontainer', label: 'Dev Container' },
   { repo: 'marketplace', label: 'Marketplace' },
-  { repo: 'claude-code-proxy', label: 'Claude Code Proxy' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary
- Remove Claude Code Proxy mega-menu entry from `config.ts`
- Remove Claude Code Proxy federated search entry from `config.ts`

## Context
The claude-code-proxy repo has been stripped of ecosystem artifacts (PR f5xc-salesdemos/claude-code-proxy#62). These upstream references should be cleaned up so the org's mega-menu navigation and federated search stop targeting a repo/site that no longer participates in the ecosystem.

Closes #307

🤖 Generated with [Claude Code](https://claude.com/claude-code)