### PR TITLE
fix: add --browserUrl to chrome-devtools MCP config

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,10 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "chrome-devtools-mcp@latest", "--browserUrl=http://localhost:9222"],
+      "env": {}
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `--browserUrl=http://localhost:9222` to the chrome-devtools MCP server args in `.mcp.json`
- Connects to the shared Chrome instance on port 9222 instead of launching a separate browser that conflicts on the profile lock

## Related

Closes #313
Related: f5xc-salesdemos/devcontainer#435

## Test plan

- [ ] Verify `.mcp.json` args include `--browserUrl=http://localhost:9222`
- [ ] Confirm chrome-devtools MCP connects to the shared Chrome instance in the dev container

🤖 Generated with [Claude Code](https://claude.com/claude-code)