### PR TITLE
feat: add oh-my-xcsh to mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -271,6 +271,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
+            {
+              label: 'Oh My XCSh',
+              description: 'Multi-model agent orchestration',
+              href: 'https://f5xc-salesdemos.github.io/oh-my-xcsh/',
+              icon: resolveIcon('f5xc:ai_assistant_logo'),
+            },
           ],
         },
       ],
@@ -375,6 +381,7 @@ const federatedSearchSites = [
   { repo: 'marketplace', label: 'Marketplace' },
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
+  { repo: 'oh-my-xcsh', label: 'Oh My XCSh' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary
- Add Oh My XCSh entry to the AI category in the mega menu navigation
- Add oh-my-xcsh to the federated search sites list

## Test plan
- [ ] Verify config.ts syntax valid
- [ ] After merge, confirm oh-my-xcsh appears in AI mega menu dropdown

Closes #399

Generated with [Claude Code](https://claude.com/claude-code)