### PR TITLE
chore: remove deprecated xcsh repos from theme config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -271,18 +271,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
-            {
-              label: 'Oh My XCSh',
-              description: 'Multi-model agent orchestration',
-              href: 'https://f5xc-salesdemos.github.io/oh-my-xcsh/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
-            {
-              label: 'XCSh',
-              description: 'AI-powered development CLI',
-              href: 'https://f5xc-salesdemos.github.io/xcsh/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
           ],
         },
       ],
@@ -387,8 +375,6 @@ const federatedSearchSites = [
   { repo: 'marketplace', label: 'Marketplace' },
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
-  { repo: 'oh-my-xcsh', label: 'Oh My XCSh' },
-  { repo: 'xcsh', label: 'XCSh' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary
- Removed Oh My XCSh and XCSh from navigation dropdown items in `config.ts`
- Removed from related repos array in `config.ts`
- These repos are being deprecated and their links will stop working

## Test plan
- [ ] Verify navigation dropdown renders correctly without removed items
- [ ] Verify related repos section works without removed entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)