### PR TITLE
chore: remove oh-my-xcsh from theme navigation and repo list

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -272,12 +272,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
             {
-              label: 'Oh My XCSh',
-              description: 'Multi-model agent orchestration',
-              href: 'https://f5xc-salesdemos.github.io/oh-my-xcsh/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
-            {
               label: 'XCSh',
               description: 'AI-powered development CLI',
               href: 'https://f5xc-salesdemos.github.io/xcsh/',
@@ -387,7 +381,6 @@ const federatedSearchSites = [
   { repo: 'marketplace', label: 'Marketplace' },
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
-  { repo: 'oh-my-xcsh', label: 'Oh My XCSh' },
   { repo: 'xcsh', label: 'XCSh' },
 ];
 


### PR DESCRIPTION
## Summary

- Remove Oh My XCSh navigation menu entry from `config.ts`
- Remove Oh My XCSh repository list entry from `config.ts`

The oh-my-xcsh repository was renamed and is no longer a standalone project in the f5xc-salesdemos ecosystem. Keeping references to it causes broken links in the documentation theme navigation.

Closes #422

## Test plan

- [ ] CI checks pass
- [ ] Documentation site builds successfully without the removed entries
- [ ] Navigation menu no longer shows Oh My XCSh link