### PR TITLE
chore(deps): bump vite to 7.3.2 to patch CVE-2026-39363/39364/39365

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9138,9 +9138,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "7.3.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
+      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",


### PR DESCRIPTION
Closes #466

## Summary

Vite 7.3.1 → 7.3.2 via `npm update vite`. Patches three disclosed CVEs within the existing `^7.3.1` range (no peer-dependency churn).

- CVE-2026-39363 (HIGH) — WebSocket access-control bypass
- CVE-2026-39364 (HIGH) — query-parameter info disclosure
- CVE-2026-39365 (MEDIUM) — `.map` path traversal on dev server

Unblocks governance PR #465, whose upstream sync removes the `.trivyignore` suppressions for these CVEs.

## Scope

- `package-lock.json` only — no runtime behavior change.
- `npm ls vite` confirms `vite@7.3.2` everywhere it is resolved in the tree.

## Test plan

- [ ] CI checks pass (`Check linked issues`, `Lint Code Base`)
- [ ] No other dependency versions shift