### PR TITLE
chore: remove deprecated xcsh repo from theme config

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -271,12 +271,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
-            {
-              label: 'XCSh',
-              description: 'AI-powered development CLI',
-              href: 'https://f5xc-salesdemos.github.io/xcsh/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
           ],
         },
       ],
@@ -381,7 +375,6 @@ const federatedSearchSites = [
   { repo: 'marketplace', label: 'Marketplace' },
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
-  { repo: 'xcsh', label: 'XCSh' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
Closes #468

Removes the `XCSh` mega-menu item and the `{ repo: 'xcsh', label: 'XCSh' }` entry from `federatedSearchSites` in `config.ts`. The `xcsh` repo is being deprecated and its links will stop resolving.

Supersedes stale PR #417 (CONFLICTING, no linked issue).