### PR TITLE
docs: add MVP product plan to menu and fix xcsh label casing

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -218,6 +218,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/devcontainer/',
               icon: resolveIcon('hashicorp-flight:docker-color'),
             },
+            {
+              label: 'xcsh Product Plan',
+              description: 'Executive product plan and engineering roadmap for xcsh',
+              href: 'https://f5xc-salesdemos.github.io/mvp/',
+              icon: resolveIcon('f5xc:ai_assistant_logo'),
+            },
           ],
         },
         {
@@ -272,7 +278,7 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },
             {
-              label: 'XCSh',
+              label: 'xcsh',
               description: 'AI-powered development CLI with persistent sessions and native Rust tooling',
               href: 'https://f5xc-salesdemos.github.io/xcsh/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),

--- a/config.ts
+++ b/config.ts
@@ -219,8 +219,8 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('hashicorp-flight:docker-color'),
             },
             {
-              label: 'xcsh Product Plan',
-              description: 'Executive product plan and engineering roadmap for xcsh',
+              label: 'mvp',
+              description: 'Capability program that amplifies F5 XC account teams with an agentic subject matter expert',
               href: 'https://f5xc-salesdemos.github.io/mvp/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },

--- a/config.ts
+++ b/config.ts
@@ -220,7 +220,8 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
             },
             {
               label: 'mvp',
-              description: 'Capability program that amplifies F5 XC account teams with an agentic subject matter expert',
+              description:
+                'Capability program that amplifies F5 XC account teams with an agentic subject matter expert',
               href: 'https://f5xc-salesdemos.github.io/mvp/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },


### PR DESCRIPTION
## What

- Adds a new entry for `f5xc-salesdemos/MVP` (xcsh executive product plan) under Platform → Documentation Tools.
- Corrects the existing `XCSh` label to the canonical lowercase `xcsh` in AI → AI Tools.

## Why

- MVP publishes executive-level product-plan docs for xcsh; reviewers need a menu entry to reach them from any docs site.
- The project naming rule requires `xcsh` to always be lowercase; the existing `XCSh` label violates it.

## Testing

- `git diff` shows only the intended additions and the single-word label change.
- No plugin, integration, or build config is touched.

Closes #488