### PR TITLE
docs: broaden mvp menu description to F5 XC practitioners

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -221,7 +221,7 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
             {
               label: 'mvp',
               description:
-                'Capability program that amplifies F5 XC account teams with an agentic subject matter expert',
+                'Capability program that amplifies F5 Distributed Cloud practitioners with an agentic subject matter expert',
               href: 'https://f5xc-salesdemos.github.io/mvp/',
               icon: resolveIcon('f5xc:ai_assistant_logo'),
             },


### PR DESCRIPTION
## What

Updates the mvp entry in the Platform \u2192 Documentation Tools mega menu. Description changes from \"Capability program that amplifies F5 XC account teams...\" to \"Capability program that amplifies F5 Distributed Cloud practitioners...\".

## Why

xcsh is used by F5 sales account teams, F5 professional services, and F5 customers. Public menu copy should not narrow the audience.

## Testing

- \`git diff\` is a single-line wording change; biome format confirms no formatting issues.

Closes #490