### PR TITLE
docs: verify shared Super-Linter Biome step (docs-control#385)

### DIFF
--- a/VERIFICATION_NOOP.md
+++ b/VERIFICATION_NOOP.md
@@ -1,0 +1,1 @@
+Verification no-op — confirms docs-control Super-Linter workflow new Biome step runs correctly in docs-theme. Delete or close PR after CI reports green.


### PR DESCRIPTION
## Summary

Disposable verification PR — confirms the new Biome step added by docs-control PR #385 (merge commit `bf4c969d`, merged 2026-04-21T13:58:44Z) runs correctly in `docs-theme` via the shared `workflow_call` lint workflow.

## Related Issue

Closes #502

## Changes

- Adds `VERIFICATION_NOOP.md` at repo root (single-line placeholder)

## Verification points checked by this PR

1. Step order in Actions log: **Checkout → Setup Biome → Run Biome → Run Super-Linter → (Spectral if OpenAPI specs present)**
2. `biome ci .` passes against `docs-theme`'s fleet-synced `biome.json`
3. Super-Linter log no longer shows `BIOME_FORMAT` / `BIOME_LINT` **result** sections (static toolchain inventory may still list them; what matters is the absence of `Errors found in BIOME_*` result sections)
4. Single check name **`Lint Code Base`** is preserved (no new check names)

## Checklist

- [x] Linked to a GitHub issue (required — CI will block merge without it)
- [x] Tested locally (pre-commit gate passed)
- [x] Follows project conventions

## Disposition

**This PR will be closed without merging** — it is a disposable verification artifact.