### PR TITLE
feat: wire @f5xc-salesdemos/starlight-llms-txt options for llms.txt hierarchy

### DIFF
--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -1,7 +1,7 @@
 ---
 import { Icon as StarlightIcon } from '@astrojs/starlight/components';
-import { hasExplicitColors } from '../src/utils/resolve-icon';
 import type { IconSetData } from '../src/types/icon';
+import { hasExplicitColors } from '../src/utils/resolve-icon';
 
 interface Props {
   name: string;

--- a/config.ts
+++ b/config.ts
@@ -1,11 +1,11 @@
 import react from '@astrojs/react';
 import starlight from '@astrojs/starlight';
 import type { StarlightPlugin } from '@astrojs/starlight/types';
+import starlightLlmsTxt from '@f5xc-salesdemos/starlight-llms-txt';
 import type { AstroIntegration } from 'astro';
 import { defineConfig } from 'astro/config';
 import starlightHeadingBadges from 'starlight-heading-badges';
 import starlightImageZoom from 'starlight-image-zoom';
-import starlightLlmsTxt from '@f5xc-salesdemos/starlight-llms-txt';
 import starlightMegaMenu from 'starlight-mega-menu';
 import starlightPageActions from 'starlight-page-actions';
 import { starlightIconsPlugin } from 'starlight-plugin-icons';

--- a/config.ts
+++ b/config.ts
@@ -5,7 +5,7 @@ import type { AstroIntegration } from 'astro';
 import { defineConfig } from 'astro/config';
 import starlightHeadingBadges from 'starlight-heading-badges';
 import starlightImageZoom from 'starlight-image-zoom';
-import starlightLlmsTxt from 'starlight-llms-txt';
+import starlightLlmsTxt from '@f5xc-salesdemos/starlight-llms-txt';
 import starlightMegaMenu from 'starlight-mega-menu';
 import starlightPageActions from 'starlight-page-actions';
 import { starlightIconsPlugin } from 'starlight-plugin-icons';
@@ -399,6 +399,8 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   const githubRepository = options.githubRepository || process.env.GITHUB_REPOSITORY || '';
   const llmsOptionalLinks =
     options.llmsOptionalLinks || (process.env.LLMS_OPTIONAL_LINKS ? JSON.parse(process.env.LLMS_OPTIONAL_LINKS) : []);
+  const llmsConfig = process.env.LLMS_CONFIG ? JSON.parse(process.env.LLMS_CONFIG) : {};
+  const llmsFederatedSites = process.env.LLMS_FEDERATED_SITES ? JSON.parse(process.env.LLMS_FEDERATED_SITES) : [];
   const megaMenuItems = options.megaMenuItems || defaultMegaMenuItems;
   const head = options.head || defaultHead;
   const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/f5-distributed-cloud.svg' };
@@ -437,6 +439,15 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       description,
       rawContent: true,
       optionalLinks: llmsOptionalLinks,
+      sidebarNav: true,
+      customSets: llmsConfig.customSets || [],
+      promote: llmsConfig.promote || ['index*', 'overview*'],
+      demote: llmsConfig.demote || ['references*'],
+      perPageMarkdown: {
+        extensionStrategy: 'append',
+        excludePages: ['index*'],
+      },
+      ...(llmsFederatedSites.length > 0 ? { federatedSites: llmsFederatedSites } : {}),
     }),
   ];
 

--- a/package.json
+++ b/package.json
@@ -107,7 +107,7 @@
     "unist-util-visit": "^5.0.0",
     "starlight-heading-badges": "^0.7.0",
     "starlight-image-zoom": "^0.14.1",
-    "starlight-llms-txt": "^0.8.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
     "starlight-mega-menu": "^1.0.1",
     "starlight-page-actions": "^0.5.0",
     "starlight-plugin-icons": "^1.1.3",


### PR DESCRIPTION
Refs f5xc-salesdemos/xcsh#223 (Step 3)

- Swap `starlight-llms-txt` → `@f5xc-salesdemos/starlight-llms-txt`
- Enable `sidebarNav: true` (sidebar hierarchy in llms.txt with automatic frontmatter descriptions)
- Enable `perPageMarkdown` with append strategy and `excludePages: ["index*"]`
- Wire `customSets`, `promote`, `demote` from `LLMS_CONFIG` env var (set by docs-builder entrypoint from `llms-config.json`)
- Wire `federatedSites` from `LLMS_FEDERATED_SITES` env var (set by docs-builder entrypoint from `llms-federated-sites.json`)

Defaults: promote index/overview pages, demote references, no customSets when env var absent.