### PR TITLE
chore: remove api-mcp megamenu item and repos-list entry

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -267,12 +267,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
           title: 'AI Tools',
           items: [
             {
-              label: 'API MCP Server',
-              description: 'MCP server for F5 XC API',
-              href: 'https://f5xc-salesdemos.github.io/api-mcp/',
-              icon: resolveIcon('f5xc:ai_assistant_logo'),
-            },
-            {
               label: 'Marketplace',
               description: 'AI-powered marketplace for F5 XC',
               href: 'https://f5xc-salesdemos.github.io/marketplace/',
@@ -381,7 +375,6 @@ const federatedSearchSites = [
   { repo: 'ddos', label: 'DDoS' },
   { repo: 'waf', label: 'WAF' },
   { repo: 'api-protection', label: 'API Security' },
-  { repo: 'api-mcp', label: 'API MCP' },
   { repo: 'xcsh', label: 'XCSh' },
   { repo: 'csd', label: 'Client-Side Defense' },
   { repo: 'docs-icons', label: 'Docs Icons' },


### PR DESCRIPTION
## Summary

- Remove the "API MCP Server" LinkCard from the AI Tools megamenu category in `config.ts`.
- Remove `{ repo: 'api-mcp', label: 'API MCP' }` from the repos list in the same file.

Part of the MCP decommission. The `api-mcp` repo has been archived (read-only) as of 2026-04-22. `terraform-provider-mcp` is not referenced in docs-theme — no change needed for it here.

## Verification

- Grep for `api-mcp` and `terraform-provider-mcp` in the file: zero matches after edit.
- Diff: 7 deletions, 0 insertions.
- TypeScript/build validation runs in CI.

Closes #515

See also the master tracking issue at f5xc-salesdemos/docs-control#393.