### PR TITLE
feat: add cdn-simulator to mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -148,6 +148,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('f5xc:content-delivery-network'),
             },
             {
+              label: 'CDN Simulator',
+              description: 'NGINX-based CDN edge node for labs',
+              href: 'https://f5xc-salesdemos.github.io/cdn-simulator/',
+              icon: resolveIcon('f5xc:content-delivery-network'),
+            },
+            {
               label: 'DNS Load Balancing',
               description: 'DNS management and zones',
               href: 'https://f5xc-salesdemos.github.io/dns/',
@@ -382,6 +388,7 @@ const federatedSearchSites = [
   { repo: 'marketplace', label: 'Marketplace' },
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
+  { repo: 'cdn-simulator', label: 'CDN Simulator' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7476,9 +7476,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
       "funding": [
         {
           "type": "opencollective",


### PR DESCRIPTION
## Summary

- Add "CDN Simulator" mega menu item under Networking > Connectivity & Delivery, alongside Content Delivery
- Add cdn-simulator to the federatedSearchSites array for cross-site search discovery

Closes #528

## Test plan

- [ ] CI checks pass
- [ ] Verify mega menu renders CDN Simulator item in correct category
- [ ] Verify federated search includes cdn-simulator results