### PR TITLE
feat: add CDN Simulator and Origin Server to mega menu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -154,6 +154,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('f5xc:content-delivery-network'),
             },
             {
+              label: 'Origin Server',
+              description: 'Vulnerable web apps origin for labs',
+              href: 'https://f5xc-salesdemos.github.io/origin-server/',
+              icon: resolveIcon('f5xc:distributed-apps'),
+            },
+            {
               label: 'DNS Load Balancing',
               description: 'DNS management and zones',
               href: 'https://f5xc-salesdemos.github.io/dns/',
@@ -389,6 +395,7 @@ const federatedSearchSites = [
   { repo: 'api-specs', label: 'API Specs' },
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
   { repo: 'cdn-simulator', label: 'CDN Simulator' },
+  { repo: 'origin-server', label: 'Origin Server' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary

- Add CDN Simulator and Origin Server entries to the Networking section of the mega menu in `config.ts`
- Add both repos (`cdn-simulator`, `origin-server`) to the `federatedSearchSites` array for federated search

CDN Simulator was already registered in `downstream-repos.json` and `docs-sites.json` but was missing from the mega menu and federated search. Origin Server is a new addition. This change maintains consistency across the ecosystem.

Closes #530

## Test plan

- [ ] CI checks pass
- [ ] Verify mega menu renders CDN Simulator and Origin Server entries in the Networking section
- [ ] Verify federated search includes results from cdn-simulator and origin-server repos