### PR TITLE
fix: standardize xcsh label casing to lowercase

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -387,7 +387,7 @@ const federatedSearchSites = [
   { repo: 'ddos', label: 'DDoS' },
   { repo: 'waf', label: 'WAF' },
   { repo: 'api-protection', label: 'API Security' },
-  { repo: 'xcsh', label: 'XCSh' },
+  { repo: 'xcsh', label: 'xcsh' },
   { repo: 'csd', label: 'Client-Side Defense' },
   { repo: 'docs-icons', label: 'Docs Icons' },
   { repo: 'devcontainer', label: 'Dev Container' },


### PR DESCRIPTION
## Summary

- Standardize the `xcsh` label in federated search configuration from `XCSh` to `xcsh`
- Enforces ecosystem-wide codespell requirement for lowercase product name

Closes #536

## Test plan

- [ ] CI checks pass
- [ ] Federated search label renders as lowercase `xcsh`