### PR TITLE
docs: add icons description and llms-config for llms.txt hierarchy

### DIFF
--- a/docs/icons.mdx
+++ b/docs/icons.mdx
@@ -1,5 +1,6 @@
 ---
 title: Icons
+description: Redirect to the Icons documentation site.
 sidebar:
   order: 99
 head:

--- a/docs/llms-config.json
+++ b/docs/llms-config.json
@@ -1,0 +1,16 @@
+{
+  "customSets": [
+    {
+      "label": "Diagrams",
+      "description": "Mermaid diagram templates for F5 XC architecture, cloud, and security topics",
+      "paths": ["diagrams/**"]
+    },
+    {
+      "label": "Configuration",
+      "description": "Astro config, environment variables, and build pipeline setup",
+      "paths": ["astro-config*", "environment-variables*", "build-pipeline*"]
+    }
+  ],
+  "promote": ["index*", "components*", "astro-config*"],
+  "demote": ["icons*"]
+}


### PR DESCRIPTION
## Summary

- Add `description` frontmatter field to `docs/icons.mdx` for llms.txt generation
- Add `docs/llms-config.json` configuration file defining the llms.txt section hierarchy

Closes #544

Refs f5xc-salesdemos/xcsh#223

## Test plan

- [ ] CI checks pass
- [ ] Verify `docs/llms-config.json` passes Biome lint
- [ ] Verify `docs/icons.mdx` frontmatter is valid