### PR TITLE
fix: set rawContent false so llms-txt resolves remark-code-import file references

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -465,7 +465,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
     starlightLlmsTxt({
       projectName: title,
       description,
-      rawContent: true,
+      rawContent: false,
       optionalLinks: llmsOptionalLinks,
       sidebarNav: true,
       customSets: llmsConfig.customSets || [],


### PR DESCRIPTION
## Summary

- Set `rawContent: false` in the starlight-llms-txt plugin config so Astro's `render()` pipeline processes remark plugins (including remark-code-import) before generating llms-full.txt
- Fixes empty code blocks in llms-full.txt for repos using `file=` references (origin-server, cdn-simulator)

Closes #559

## Test plan

- [ ] CI checks pass
- [ ] Verify llms-full.txt in origin-server build contains resolved file= content instead of empty code blocks
- [ ] Verify llms-full.txt in cdn-simulator build contains resolved file= content