### PR TITLE
feat(nav): add traffic-generator to megamenu and federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -161,6 +161,12 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               icon: resolveIcon('f5xc:distributed-apps'),
             },
             {
+              label: 'Traffic Generator',
+              description: 'Security testing tools for traffic generation',
+              href: 'https://f5xc-salesdemos.github.io/traffic-generator/',
+              icon: resolveIcon('f5xc:application-traffic-insight'),
+            },
+            {
               label: 'DNS Load Balancing',
               description: 'DNS management and zones',
               href: 'https://f5xc-salesdemos.github.io/dns/',
@@ -397,6 +403,7 @@ const federatedSearchSites = [
   { repo: 'api-specs-enriched', label: 'API Specs Enriched' },
   { repo: 'cdn-simulator', label: 'CDN Simulator' },
   { repo: 'origin-server', label: 'Origin Server' },
+  { repo: 'traffic-generator', label: 'Traffic Generator' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {


### PR DESCRIPTION
## Summary

- Add traffic-generator to the megamenu under Connectivity & Delivery category with the `f5xc:application-traffic-insight` icon
- Add traffic-generator to the federated search sites list
- Completes ecosystem navigation alongside cdn-simulator and origin-server which are already present

Closes #562

## Test plan

- [ ] CI checks pass
- [ ] Megamenu renders traffic-generator entry in Connectivity & Delivery category
- [ ] Federated search includes traffic-generator results