### PR TITLE
feat: parse LLMS_FEDERATED_SITE_CATEGORIES env var and pass to plugin

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -436,6 +436,14 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       console.warn('[docs-theme] LLMS_FEDERATED_SITES contains invalid JSON; using defaults.', e);
     }
   }
+  let llmsFederatedSiteCategories: unknown[] = [];
+  if (process.env.LLMS_FEDERATED_SITE_CATEGORIES) {
+    try {
+      llmsFederatedSiteCategories = JSON.parse(process.env.LLMS_FEDERATED_SITE_CATEGORIES);
+    } catch (e) {
+      console.warn('[docs-theme] LLMS_FEDERATED_SITE_CATEGORIES contains invalid JSON; using defaults.', e);
+    }
+  }
   const megaMenuItems = options.megaMenuItems || defaultMegaMenuItems;
   const head = options.head || defaultHead;
   const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/f5-distributed-cloud.svg' };
@@ -483,6 +491,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
         excludePages: ['index*'],
       },
       ...(llmsFederatedSites.length > 0 ? { federatedSites: llmsFederatedSites } : {}),
+      ...(llmsFederatedSiteCategories.length > 0 ? { federatedSiteCategories: llmsFederatedSiteCategories } : {}),
     }),
   ];
 


### PR DESCRIPTION
## Summary

- Parses the new `LLMS_FEDERATED_SITE_CATEGORIES` environment variable as JSON
- Passes the parsed array to `starlightLlmsTxt()` as the `federatedSiteCategories` option
- Follows the same try/catch pattern used for `LLMS_FEDERATED_SITES` to handle invalid JSON gracefully

Closes #566

## Test plan

- [ ] CI checks pass
- [ ] Verify config.ts parses the env var when present
- [ ] Verify graceful fallback to empty array when env var is missing or invalid JSON