### PR TITLE
chore: bump starlight-llms-txt to 1.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.0",
-        "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
+        "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
         "starlight-image-zoom": "^0.14.1",
@@ -1175,9 +1175,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.0.0.tgz",
-      "integrity": "sha512-xkwsfSLUfbh3PS10YEeuvCgeyL9YmBUiWtqNBW5OxlmNemvnq0cDgodfbAEyLNGMOLQGVl1kXlegkM9pukklUg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.1.0.tgz",
+      "integrity": "sha512-8Bw4Hj/PVhYkACtfD3rqD2xIWA2+ROChhLqfOongmbwOYcwTZ90Z+zOHJXoB0EWy49xNhzZK0Psn9Tr4vKVhkw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
-    "@f5xc-salesdemos/starlight-llms-txt": "^1.0.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",
     "starlight-image-zoom": "^0.14.1",


### PR DESCRIPTION
## Summary

- Update `@f5xc-salesdemos/starlight-llms-txt` from `^1.0.0` to exact `1.1.0`
- v1.1.0 adds categorized federation support (`federatedSiteCategories` option) needed for progressive component discovery
- Pins exact version to activate categorized llms.txt rendering that groups federated sites by category

Closes #576

## Test plan

- [ ] CI checks pass
- [ ] Verify package installs correctly with exact version pin
- [ ] Verify llms.txt rendering with categorized federation support