### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,3 +1,3 @@
 [codespell]
 skip = *.json,*.lock,*/tools/generated/*,vendor/*,*/vendored/*,*-vendored*,*/fixtures/*,*.min.js,*.jsonl,*.b64.js,*/gen/*,node_modules,target,dist,.git,packages/*/dist,crates/*/vendored
-ignore-words-list = afterall,aks,anull,datas,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine
+ignore-words-list = afterall,aks,anull,datas,deliverys,edn,hcl,ists,iterm,nd,nin,observ,pre-select,pre-selected,pre-selects,preceeding,uncomplete,ves,doesnt,forin,statics,ser,anc,abd,fo,te,runn,crossreferences,prevend,aline,invokable,takin,hel,unparseable,defaul,doub,cros,deine

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -19,3 +19,21 @@ disable=SC2064
 # Disable SC2086: Double quote to prevent globbing and word splitting.
 # Pipeline scripts and attack suites intentionally rely on word splitting.
 disable=SC2086
+
+# Disable SC2030: Modification of variable is local to subshell.
+# Parallel execution uses backgrounded subshells by design.
+disable=SC2030
+
+# Disable SC2031: Variable was modified in a subshell.
+disable=SC2031
+
+# Disable SC2045: Iterating over ls output is fragile.
+# Runner scripts iterate over numbered scripts in controlled directories.
+disable=SC2045
+
+# Disable SC2012: Use find instead of ls.
+disable=SC2012
+
+# Disable SC2001: See if you can use ${variable//search/replace}.
+# Scripts use sed for complex regex patterns.
+disable=SC2001


### PR DESCRIPTION
Closes #584

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- README.md
- .shellcheckrc
- .codespellrc