### PR TITLE
feat: add Tools megamenu category with VS Code Extension and xcsh

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -351,6 +351,31 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
       ],
     },
   },
+  {
+    label: 'Tools',
+    content: {
+      layout: 'list',
+      categories: [
+        {
+          title: 'Developer Tools',
+          items: [
+            {
+              label: 'VS Code Extension',
+              description: 'Manage F5 XC resources from VS Code',
+              href: 'https://f5xc-salesdemos.github.io/vscode-f5xc-tools/',
+              icon: resolveIcon('carbon:code'),
+            },
+            {
+              label: 'xcsh CLI',
+              description: 'AI-powered CLI for F5 XC',
+              href: 'https://f5xc-salesdemos.github.io/xcsh/',
+              icon: resolveIcon('carbon:terminal'),
+            },
+          ],
+        },
+      ],
+    },
+  },
 ];
 
 const defaultHead: HeadEntry[] = [


### PR DESCRIPTION
## Summary

- Add new top-level **Tools** category to the megamenu in `config.ts`
- Include **VS Code Extension** and **xcsh CLI** entries under a "Developer Tools" subcategory
- Provides discoverable navigation for developer-facing tools

Closes #654

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Megamenu renders the new Tools category correctly in the docs theme
- [ ] VS Code Extension and xcsh CLI links resolve to the correct GitHub Pages sites