### PR TITLE
feat: add subcategory-based sidebar generation from frontmatter

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -15,6 +15,7 @@ import starlightVideosPlugin from 'starlight-videos';
 import f5xcDocsTheme from './index.ts';
 import remarkMermaid from './src/plugins/remark-mermaid.mjs';
 import { resolveIcon } from './src/utils/resolve-icon.ts';
+import { buildSubcategorySidebar } from './src/utils/subcategory-sidebar.ts';
 
 interface MegaMenuItem {
   label: string;
@@ -539,6 +540,9 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
     }),
   ];
 
+  const contentDir = process.env.CONTENT_DIR || 'src/content/docs';
+  const subcategorySidebar = buildSubcategorySidebar(contentDir);
+
   return defineConfig({
     site,
     base,
@@ -551,6 +555,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
         plugins: starlightPlugins,
         head: head as Parameters<typeof starlight>[0]['head'],
         logo: logo as Parameters<typeof starlight>[0]['logo'],
+        ...(subcategorySidebar ? { sidebar: subcategorySidebar } : {}),
         ...(mergeIndex && mergeIndex.length > 0 ? { pagefind: { mergeIndex } } : {}),
         ...(githubRepository
           ? {

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "@astrojs/react": "^5.0.0",
         "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
+        "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
         "starlight-image-zoom": "^0.14.1",
@@ -4772,6 +4773,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "license": "BSD-2-Clause",
+      "bin": {
+        "esparse": "bin/esparse.js",
+        "esvalidate": "bin/esvalidate.js"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/estree-util-attach-comments": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/estree-util-attach-comments/-/estree-util-attach-comments-3.0.0.tgz",
@@ -4888,6 +4902,18 @@
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
       "license": "MIT"
+    },
+    "node_modules/extend-shallow": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
+      "integrity": "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extendable": "^0.1.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/fast-string-truncated-width": {
       "version": "1.2.1",
@@ -5057,6 +5083,43 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/gray-matter": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/gray-matter/-/gray-matter-4.0.3.tgz",
+      "integrity": "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-yaml": "^3.13.1",
+        "kind-of": "^6.0.2",
+        "section-matter": "^1.0.0",
+        "strip-bom-string": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/gray-matter/node_modules/argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "license": "MIT",
+      "dependencies": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "node_modules/gray-matter/node_modules/js-yaml": {
+      "version": "3.14.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.14.2.tgz",
+      "integrity": "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg==",
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/gzip-size": {
@@ -5645,6 +5708,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/is-extendable": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-0.1.1.tgz",
+      "integrity": "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -5825,6 +5897,15 @@
       },
       "engines": {
         "node": ">=6"
+      }
+    },
+    "node_modules/kind-of": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
+      "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/klona": {
@@ -8204,6 +8285,19 @@
       "license": "MIT",
       "peer": true
     },
+    "node_modules/section-matter": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/section-matter/-/section-matter-1.0.0.tgz",
+      "integrity": "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA==",
+      "license": "MIT",
+      "dependencies": {
+        "extend-shallow": "^2.0.1",
+        "kind-of": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/semver": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
@@ -8407,6 +8501,12 @@
         "url": "https://github.com/sponsors/wooorm"
       }
     },
+    "node_modules/sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/srt-parser-2": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/srt-parser-2/-/srt-parser-2-1.2.3.tgz",
@@ -8561,6 +8661,15 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/strip-bom-string": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/strip-bom-string/-/strip-bom-string-1.0.0.tgz",
+      "integrity": "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-indent": {

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
   "dependencies": {
     "@astrojs/react": "^5.0.0",
     "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
+    "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",
     "starlight-image-zoom": "^0.14.1",

--- a/src/utils/subcategory-sidebar.ts
+++ b/src/utils/subcategory-sidebar.ts
@@ -1,0 +1,235 @@
+import fs from 'node:fs';
+import path from 'node:path';
+import matter from 'gray-matter';
+
+/**
+ * Starlight sidebar config types (simplified).
+ */
+type SidebarLink = { label: string; link: string };
+type SidebarGroup = { label: string; items: SidebarItem[]; collapsed?: boolean };
+type SidebarItem = SidebarLink | SidebarGroup;
+
+type DocType = 'resource' | 'data-source' | 'guide' | 'function';
+
+interface DocEntry {
+  title: string;
+  subcategory: string | undefined;
+  docType: DocType;
+  slug: string;
+}
+
+/**
+ * Detect the doc type from a file path relative to the content directory.
+ * Matches the first path segment against known prefixes.
+ */
+function detectDocType(relativePath: string): DocType | undefined {
+  const normalized = relativePath.replace(/\\/g, '/');
+  if (normalized.startsWith('resources/')) return 'resource';
+  if (normalized.startsWith('data-sources/')) return 'data-source';
+  if (normalized.startsWith('guides/')) return 'guide';
+  if (normalized.startsWith('functions/')) return 'function';
+  return undefined;
+}
+
+/**
+ * Recursively collect all .md and .mdx files under a directory.
+ */
+function collectMarkdownFiles(dir: string): string[] {
+  const results: string[] = [];
+  if (!fs.existsSync(dir)) return results;
+
+  const entries = fs.readdirSync(dir, { withFileTypes: true });
+  for (const entry of entries) {
+    const fullPath = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      results.push(...collectMarkdownFiles(fullPath));
+    } else if (entry.isFile() && /\.mdx?$/.test(entry.name)) {
+      results.push(fullPath);
+    }
+  }
+  return results;
+}
+
+/**
+ * Strip the provider suffix from a page_title to get a clean display title.
+ * e.g. "f5xc_api_crawler Resource - volterratf5xc" → "f5xc_api_crawler"
+ */
+function cleanPageTitle(pageTitle: string): string {
+  return pageTitle.replace(/\s+(Resource|Data Source)\s*-\s*.*$/i, '').trim();
+}
+
+/**
+ * Convert a file path relative to the content dir into a Starlight link slug.
+ * e.g. "resources/api_crawler.md" → "/resources/api_crawler/"
+ *      "guides/getting-started.md" → "/guides/getting-started/"
+ *      "index.md" → "/"
+ */
+function filePathToSlug(relativePath: string): string {
+  const normalized = relativePath
+    .replace(/\\/g, '/')
+    .replace(/\.mdx?$/, '')
+    .replace(/\/index$/, '');
+
+  if (normalized === 'index' || normalized === '') return '/';
+  return `/${normalized}/`;
+}
+
+/**
+ * Scan the content directory for .md/.mdx files, parse frontmatter,
+ * and build a Starlight sidebar config grouped by subcategory.
+ *
+ * Returns `undefined` if no files contain a `subcategory` field,
+ * letting Starlight fall back to directory-based auto-generation.
+ */
+export function buildSubcategorySidebar(contentDir: string): SidebarItem[] | undefined {
+  const resolvedDir = path.resolve(contentDir);
+  if (!fs.existsSync(resolvedDir)) {
+    console.warn(`[subcategory-sidebar] Content directory not found: ${resolvedDir}`);
+    return undefined;
+  }
+
+  const files = collectMarkdownFiles(resolvedDir);
+  const docs: DocEntry[] = [];
+  let hasAnySubcategory = false;
+  let hasOverview = false;
+
+  for (const filePath of files) {
+    const relativePath = path.relative(resolvedDir, filePath).replace(/\\/g, '/');
+    const slug = filePathToSlug(relativePath);
+
+    // Track overview page separately
+    if (slug === '/') {
+      hasOverview = true;
+      continue;
+    }
+
+    // Skip index pages — they serve as section headers, not content
+    const baseName = path.basename(relativePath, path.extname(relativePath));
+    if (baseName === 'index') continue;
+
+    const docType = detectDocType(relativePath);
+    if (!docType) continue; // skip files not in a recognized directory
+
+    let frontmatter: Record<string, unknown>;
+    try {
+      const raw = fs.readFileSync(filePath, 'utf-8');
+      const parsed = matter(raw);
+      frontmatter = parsed.data;
+    } catch {
+      continue; // skip unparseable files
+    }
+
+    // Determine title: prefer `title`, fall back to cleaned `page_title`
+    let title = '';
+    if (typeof frontmatter.title === 'string' && frontmatter.title.trim()) {
+      title = frontmatter.title.trim();
+    } else if (typeof frontmatter.page_title === 'string' && frontmatter.page_title.trim()) {
+      title = cleanPageTitle(frontmatter.page_title);
+    } else {
+      // Last resort: derive from filename
+      title = path.basename(filePath, path.extname(filePath)).replace(/[-_]/g, ' ');
+    }
+
+    const subcategory =
+      typeof frontmatter.subcategory === 'string' && frontmatter.subcategory.trim()
+        ? frontmatter.subcategory.trim()
+        : undefined;
+
+    if (subcategory) hasAnySubcategory = true;
+
+    docs.push({ title, subcategory, docType, slug });
+  }
+
+  // If no files have subcategory, return undefined for auto-generation fallback
+  if (!hasAnySubcategory) return undefined;
+
+  // Partition docs by type
+  const guides = docs.filter((d) => d.docType === 'guide');
+  const functions = docs.filter((d) => d.docType === 'function');
+  const resources = docs.filter((d) => d.docType === 'resource');
+  const dataSources = docs.filter((d) => d.docType === 'data-source');
+
+  // Alphabetical sort helper
+  const byTitle = (a: DocEntry, b: DocEntry) => a.title.localeCompare(b.title);
+
+  // Build sidebar
+  const sidebar: SidebarItem[] = [];
+
+  // 1. Overview link
+  if (hasOverview) {
+    sidebar.push({ label: 'Overview', link: '/' });
+  }
+
+  // 2. Guides group
+  if (guides.length > 0) {
+    sidebar.push({
+      label: 'Guides',
+      collapsed: true,
+      items: guides.sort(byTitle).map((g) => ({ label: g.title, link: g.slug })),
+    });
+  }
+
+  // 3. Functions group
+  if (functions.length > 0) {
+    sidebar.push({
+      label: 'Functions',
+      collapsed: true,
+      items: functions.sort(byTitle).map((f) => ({ label: f.title, link: f.slug })),
+    });
+  }
+
+  // 4. Subcategory groups (resources + data sources)
+  const subcategoryMap = new Map<string, { resources: DocEntry[]; dataSources: DocEntry[] }>();
+
+  for (const doc of [...resources, ...dataSources]) {
+    const cat = doc.subcategory || 'Uncategorized';
+    let bucket = subcategoryMap.get(cat);
+    if (!bucket) {
+      bucket = { resources: [], dataSources: [] };
+      subcategoryMap.set(cat, bucket);
+    }
+    if (doc.docType === 'resource') {
+      bucket.resources.push(doc);
+    } else {
+      bucket.dataSources.push(doc);
+    }
+  }
+
+  // Sort subcategories alphabetically, but push "Uncategorized" to the end
+  const sortedCategories = [...subcategoryMap.keys()].sort((a, b) => {
+    if (a === 'Uncategorized') return 1;
+    if (b === 'Uncategorized') return -1;
+    return a.localeCompare(b);
+  });
+
+  for (const category of sortedCategories) {
+    const entry = subcategoryMap.get(category);
+    if (!entry) continue;
+    const { resources: catResources, dataSources: catDataSources } = entry;
+    const groupItems: SidebarItem[] = [];
+
+    if (catResources.length > 0) {
+      groupItems.push({
+        label: 'Resources',
+        items: catResources.sort(byTitle).map((r) => ({ label: r.title, link: r.slug })),
+      });
+    }
+
+    if (catDataSources.length > 0) {
+      groupItems.push({
+        label: 'Data Sources',
+        items: catDataSources.sort(byTitle).map((d) => ({ label: d.title, link: d.slug })),
+      });
+    }
+
+    if (groupItems.length > 0) {
+      sidebar.push({
+        label: category,
+        collapsed: true,
+        items: groupItems,
+      });
+    }
+  }
+
+  return sidebar;
+}


### PR DESCRIPTION
## Summary

- Add subcategory-based sidebar generation utility that reads `subcategory` frontmatter from docs and groups them by subcategory > doc type > items, mirroring the Terraform Registry hierarchy
- Falls back to directory-based auto-generation when no subcategory fields are found
- Wire up the new utility in `config.ts` and add required dependencies in `package.json`

Closes #685

## Test plan

- [ ] CI checks pass
- [ ] Verify sidebar renders correctly with docs containing `subcategory` frontmatter
- [ ] Verify fallback to directory-based sidebar when no subcategory fields present
- [ ] Verify no regressions in existing sidebar behavior