### PR TITLE
chore: bump starlight-llms-txt to 1.2.0 for subcategory grouping

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.0",
-        "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
+        "@f5xc-salesdemos/starlight-llms-txt": "1.2.0",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.1.0.tgz",
-      "integrity": "sha512-8Bw4Hj/PVhYkACtfD3rqD2xIWA2+ROChhLqfOongmbwOYcwTZ90Z+zOHJXoB0EWy49xNhzZK0Psn9Tr4vKVhkw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.0.tgz",
+      "integrity": "sha512-jowhtu8S1DItvBs0qjIfrXeHoXc2tUdSfftOuFo57YvNeL96pceZDNf1XedBZ1WoxI09osPZuwmqTltq80RNYw==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
-    "@f5xc-salesdemos/starlight-llms-txt": "1.1.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "1.2.0",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",


### PR DESCRIPTION
## Summary

- Bump `@f5xc-salesdemos/starlight-llms-txt` from 1.1.0 to 1.2.0
- Version 1.2.0 adds subcategory-aware grouping to the section tree and auto-generates custom sets from frontmatter
- Required for the subcategory-driven unified documentation hierarchy feature

Closes #688

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Downstream docs sites build successfully with the updated dependency