### PR TITLE
fix: extend docsSchema with subcategory field so sidebar-nav grouping works

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,10 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({ extend: z.object({ subcategory: z.string().optional() }) }),
+  }),
 };


### PR DESCRIPTION
## Summary

- Extend `docsSchema()` in `src/content.config.ts` with `subcategory: z.string().optional()` so the field survives Starlight content collection parsing
- Without this, `d.data.subcategory` is always `undefined` in the sidebar-nav plugin, preventing `buildSubcategoryTree` from grouping resources into category-based sets

Closes #692

## Test plan

- [ ] CI checks pass
- [ ] Verify `starlight-llms-txt` sidebar-nav builds subcategory tree correctly with the extended schema
- [ ] Confirm `_llms-txt/*.txt` custom sets are linked in Sections instead of individual pages