### PR TITLE
chore: bump @f5xc-salesdemos/starlight-llms-txt to 1.2.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.0",
-        "@f5xc-salesdemos/starlight-llms-txt": "1.2.0",
+        "@f5xc-salesdemos/starlight-llms-txt": "1.2.1",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.0.tgz",
-      "integrity": "sha512-jowhtu8S1DItvBs0qjIfrXeHoXc2tUdSfftOuFo57YvNeL96pceZDNf1XedBZ1WoxI09osPZuwmqTltq80RNYw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.1.tgz",
+      "integrity": "sha512-Jq7LLoGi1GO8knO8uEl9SqTcTWt3JQjRD8h53KzoTpSEiOo7YWlRm55xXXHXPNjcLz0jh644yE9uSShDMVkQfA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
-    "@f5xc-salesdemos/starlight-llms-txt": "1.2.0",
+    "@f5xc-salesdemos/starlight-llms-txt": "1.2.1",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",


### PR DESCRIPTION
## Summary

- Bump `@f5xc-salesdemos/starlight-llms-txt` from 1.2.0 to 1.2.1
- Version 1.2.1 fixes `## Sections` to link to `_llms-txt/*.txt` custom set files instead of individual page URLs when `sidebarNav` is enabled
- This fix combined with the `content.config.ts` subcategory schema extension (PR #693) enables the correct progressive disclosure hierarchy in `llms.txt` output

Closes #694

## Test plan

- [ ] CI checks pass
- [ ] Verify downstream consumers can build successfully with the updated package