### PR TITLE
chore: bump @f5xc-salesdemos/starlight-llms-txt to 1.2.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.0",
-        "@f5xc-salesdemos/starlight-llms-txt": "1.2.1",
+        "@f5xc-salesdemos/starlight-llms-txt": "1.2.2",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
@@ -1176,9 +1176,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.1.tgz",
-      "integrity": "sha512-Jq7LLoGi1GO8knO8uEl9SqTcTWt3JQjRD8h53KzoTpSEiOo7YWlRm55xXXHXPNjcLz0jh644yE9uSShDMVkQfA==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.2.tgz",
+      "integrity": "sha512-WyXeF4YoQvJmVzeWFe3MoyGLdJah1r/qlyZ5bIpnKtcveaM8EUSbhPsKZyINFjklt/+dSW8RYmoE+bnHetEv7w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -104,7 +104,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
-    "@f5xc-salesdemos/starlight-llms-txt": "1.2.1",
+    "@f5xc-salesdemos/starlight-llms-txt": "1.2.2",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",


### PR DESCRIPTION
## Summary

- Bump `@f5xc-salesdemos/starlight-llms-txt` from 1.2.1 to 1.2.2
- Version 1.2.2 adds deduplication for Sections entries when a node matches a custom set, preventing duplicate Guides/Functions lines in llms.txt output

Closes #696

## Test plan

- [ ] CI checks pass
- [ ] Verify llms.txt output no longer contains duplicate section entries