### PR TITLE
feat: add starlight-openapi plugin support for native API documentation

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -8,6 +8,7 @@ import codeImport from 'remark-code-import';
 import starlightHeadingBadges from 'starlight-heading-badges';
 import starlightImageZoom from 'starlight-image-zoom';
 import starlightMegaMenu from 'starlight-mega-menu';
+import starlightOpenAPI from 'starlight-openapi';
 import starlightPageActions from 'starlight-page-actions';
 import { starlightIconsPlugin } from 'starlight-plugin-icons';
 import starlightScrollToTop from 'starlight-scroll-to-top';
@@ -489,6 +490,14 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       console.warn('[docs-theme] LLMS_FEDERATED_SITE_CATEGORIES contains invalid JSON; using defaults.', e);
     }
   }
+  let openAPISpecs: Array<{ base: string; schema: string; sidebar?: { label?: string; collapsed?: boolean } }> = [];
+  if (process.env.OPENAPI_SPECS_CONFIG) {
+    try {
+      openAPISpecs = JSON.parse(process.env.OPENAPI_SPECS_CONFIG);
+    } catch (e) {
+      console.warn('[docs-theme] OPENAPI_SPECS_CONFIG contains invalid JSON; skipping OpenAPI plugin.', e);
+    }
+  }
   const megaMenuItems = options.megaMenuItems || defaultMegaMenuItems;
   const head = options.head || defaultHead;
   const logo = options.logo || { src: '@f5xc-salesdemos/docs-theme/assets/f5-distributed-cloud.svg' };
@@ -522,6 +531,20 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
     starlightHeadingBadges(),
     starlightPageActions(),
     starlightIconsPlugin(),
+    ...(openAPISpecs.length > 0
+      ? [
+          starlightOpenAPI(
+            openAPISpecs.map((spec) => ({
+              base: spec.base,
+              schema: spec.schema,
+              sidebar: {
+                collapsed: spec.sidebar?.collapsed ?? true,
+                label: spec.sidebar?.label,
+              },
+            })),
+          ),
+        ]
+      : []),
     starlightLlmsTxt({
       projectName: title,
       description,

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "test:visual:update": "playwright test --update-snapshots"
   },
   "peerDependencies": {
+    "@astrojs/markdown-remark": ">=7.0.0",
     "@astrojs/starlight": ">=0.38.0",
     "@f5xc-salesdemos/icons-f5-brand": "*",
     "@f5xc-salesdemos/icons-f5xc": "*",
@@ -113,6 +114,7 @@
     "starlight-page-actions": "^0.6.0",
     "starlight-plugin-icons": "^1.1.3",
     "starlight-scroll-to-top": "^1.0.1",
+    "starlight-openapi": "^0.25.3",
     "starlight-videos": "^0.4.0",
     "unist-util-visit": "^5.0.0"
   }


### PR DESCRIPTION
## Summary

- Adds starlight-openapi dependency and @astrojs/markdown-remark peer dependency to package.json
- Adds conditional starlight-openapi plugin configuration in config.ts, activated via the OPENAPI_SPECS_CONFIG environment variable
- Replaces iframe-embedded Scalar API viewers with native Starlight pages that provide theme integration, search indexing, and deep linking

Closes #698

## Test plan

- [ ] CI checks pass (Lint Code Base, Check linked issues)
- [ ] Build succeeds without OPENAPI_SPECS_CONFIG set (backward compatible)
- [ ] Build succeeds with OPENAPI_SPECS_CONFIG pointing to valid OpenAPI spec config
- [ ] Generated API documentation pages render correctly with Starlight theme