### PR TITLE
chore: bump @f5xc-salesdemos/starlight-llms-txt to 1.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@astrojs/react": "^5.0.0",
-        "@f5xc-salesdemos/starlight-llms-txt": "1.2.2",
+        "@f5xc-salesdemos/starlight-llms-txt": "1.3.0",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
         "starlight-heading-badges": "^0.7.0",
@@ -1193,9 +1193,9 @@
       }
     },
     "node_modules/@f5xc-salesdemos/starlight-llms-txt": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.2.2.tgz",
-      "integrity": "sha512-WyXeF4YoQvJmVzeWFe3MoyGLdJah1r/qlyZ5bIpnKtcveaM8EUSbhPsKZyINFjklt/+dSW8RYmoE+bnHetEv7w==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@f5xc-salesdemos/starlight-llms-txt/-/starlight-llms-txt-1.3.0.tgz",
+      "integrity": "sha512-0d0LeWnRqFUSCetZCQLaJ2gyhNx7k5n5hcD6H6kai5Qh3DAWSi67/Jsci5G+xqMaI+R3OwmLWvfIUT/FklNR6w==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -105,7 +105,7 @@
   },
   "dependencies": {
     "@astrojs/react": "^5.0.0",
-    "@f5xc-salesdemos/starlight-llms-txt": "1.2.2",
+    "@f5xc-salesdemos/starlight-llms-txt": "1.3.0",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",
     "starlight-heading-badges": "^0.7.0",


### PR DESCRIPTION
## Summary

- Bump `@f5xc-salesdemos/starlight-llms-txt` from `1.2.2` to `1.3.0`
- Picks up the auto-tiered `.txt` hierarchy feature (v1.3.0) which replaces `customSets`/`perPageMarkdown` with `tieredHierarchy`
- The docs-theme config was already updated in PR #703 to use `tieredHierarchy: true`, but the dependency was still pinned at `1.2.2`

Closes #704

## Test plan

- [ ] CI checks pass (`Check linked issues` and `Lint Code Base`)
- [ ] Verify `package.json` shows `@f5xc-salesdemos/starlight-llms-txt` at `1.3.0`
- [ ] Verify `package-lock.json` is consistent