### PR TITLE
fix(i18n): auto-detect locale support instead of enabling by default

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -1,3 +1,5 @@
+import fs from 'node:fs';
+import path from 'node:path';
 import react from '@astrojs/react';
 import starlight from '@astrojs/starlight';
 import type { StarlightPlugin } from '@astrojs/starlight/types';
@@ -511,8 +513,6 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   const additionalIntegrations = options.additionalIntegrations || [];
 
   const federatedSearch = options.federatedSearch !== false;
-  const resolvedLocales = options.locales === false ? undefined : options.locales || f5xcDefaultLocales;
-  const resolvedDefaultLocale = options.defaultLocale || f5xcDefaultLocale;
   const normalizedBase = base.replace(/\/+$/, '');
   const mergeIndex = federatedSearch
     ? federatedSearchSites
@@ -569,6 +569,13 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
 
   const contentDir = process.env.CONTENT_DIR || 'src/content/docs';
   const subcategorySidebar = buildSubcategorySidebar(contentDir);
+
+  // Auto-detect i18n: enable locales only when content has an en/ subdirectory.
+  // Repos that haven't migrated to docs/en/ won't get a broken language selector.
+  const hasEnSubdir = fs.existsSync(path.resolve(contentDir, 'en'));
+  const resolvedLocales =
+    options.locales === false ? undefined : options.locales || (hasEnSubdir ? f5xcDefaultLocales : undefined);
+  const resolvedDefaultLocale = options.defaultLocale || f5xcDefaultLocale;
 
   return defineConfig({
     site,


### PR DESCRIPTION
## Summary

Auto-detect i18n instead of defaulting to all 13 locales. Checks if content has an `en/` subdirectory at config time — if yes, enable locales; if no, skip.

## Problem

PR #738 enabled the language selector on ALL repos by default. Unmigrated repos (those without `docs/en/`) show a language dropdown that leads to 404 pages.

## Fix

```ts
const hasEnSubdir = fs.existsSync(path.resolve(contentDir, 'en'));
const resolvedLocales = options.locales || (hasEnSubdir ? f5xcDefaultLocales : undefined);
```

## Test plan

- [ ] CSD (migrated, has `docs/en/`) still gets language selector
- [ ] Unmigrated repos (flat `docs/`) do NOT get language selector
- [ ] `locales: false` still disables i18n explicitly
- [ ] Custom `locales: {...}` still works

Closes #745

🤖 Generated with [Claude Code](https://claude.com/claude-code)