### PR TITLE
fix(i18n): add root redirect and fix translator streaming/model

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -580,6 +580,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   return defineConfig({
     site,
     base,
+    ...(resolvedLocales ? { redirects: { '/': `/${resolvedDefaultLocale}` } } : {}),
     markdown: {
       remarkPlugins: [remarkMermaid, [codeImport, { allowImportingFromOutside: true }], ...additionalRemarkPlugins],
     },

--- a/src/i18n/translator.ts
+++ b/src/i18n/translator.ts
@@ -57,12 +57,13 @@ export async function translateFile(
   while (true) {
     attempts++;
     try {
-      const response = await client.messages.create({
-        model: options.model || 'claude-sonnet-4-20250514',
+      const stream = client.messages.stream({
+        model: options.model || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514',
         max_tokens: Math.max(4096, Math.ceil(sourceLength * 2.5)),
         system: systemPrompt,
         messages: [{ role: 'user', content: englishRaw }],
       });
+      const response = await stream.finalMessage();
 
       const textBlock = response.content.find((b) => b.type === 'text');
       if (textBlock?.type !== 'text') {


### PR DESCRIPTION
## Summary

- Add Astro redirect from `/` to `/en/` when i18n locales are active
- Switch translator to streaming API (Anthropic SDK requirement)
- Support `ANTHROPIC_MODEL` env var for proxy environments

## Problem

With all locales in subdirectories, `/csd/` returns 404 because Starlight prefixes all routes with the locale. Users hitting the root URL get nothing.

## Test plan

- [ ] `/csd/` redirects to `/csd/en/`
- [ ] `/csd/fr/overview/` still serves French content
- [ ] Unmigrated repos (no `en/` dir) are unaffected
- [ ] Translation CLI works with streaming + ANTHROPIC_MODEL

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)