### PR TITLE
fix(i18n): include base path in root-to-locale redirect

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -580,7 +580,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
   return defineConfig({
     site,
     base,
-    ...(resolvedLocales ? { redirects: { '/': `/${resolvedDefaultLocale}` } } : {}),
+    ...(resolvedLocales ? { redirects: { '/': `${normalizedBase}/${resolvedDefaultLocale}/` } } : {}),
     markdown: {
       remarkPlugins: [remarkMermaid, [codeImport, { allowImportingFromOutside: true }], ...additionalRemarkPlugins],
     },


### PR DESCRIPTION
## Summary

Fix redirect from `/` → `/en` to include the base path: `/csd/` → `/csd/en/`

## Problem

`/csd/` was redirecting to `/en` (missing base path) instead of `/csd/en/`.

Closes #749

🤖 Generated with [Claude Code](https://claude.com/claude-code)