### PR TITLE
fix(i18n): merge hero fields from translated output

### DIFF
--- a/src/i18n/translator.ts
+++ b/src/i18n/translator.ts
@@ -92,6 +92,17 @@ export async function translateFile(
   if (translatedFrontmatter.sidebar?.label) {
     mergedFrontmatter.sidebar = { ...mergedFrontmatter.sidebar, label: translatedFrontmatter.sidebar.label };
   }
+  if (translatedFrontmatter.hero) {
+    mergedFrontmatter.hero = { ...mergedFrontmatter.hero };
+    if (translatedFrontmatter.hero.tagline) mergedFrontmatter.hero.tagline = translatedFrontmatter.hero.tagline;
+    if (translatedFrontmatter.hero.title) mergedFrontmatter.hero.title = translatedFrontmatter.hero.title;
+    if (translatedFrontmatter.hero.actions) {
+      mergedFrontmatter.hero.actions = mergedFrontmatter.hero.actions?.map((action: Record<string, unknown>, i: number) => ({
+        ...action,
+        text: translatedFrontmatter.hero.actions?.[i]?.text || action.text,
+      }));
+    }
+  }
 
   mergedFrontmatter.i18n = { sourceHash, translator: 'machine' };
 

--- a/src/i18n/translator.ts
+++ b/src/i18n/translator.ts
@@ -97,10 +97,12 @@ export async function translateFile(
     if (translatedFrontmatter.hero.tagline) mergedFrontmatter.hero.tagline = translatedFrontmatter.hero.tagline;
     if (translatedFrontmatter.hero.title) mergedFrontmatter.hero.title = translatedFrontmatter.hero.title;
     if (translatedFrontmatter.hero.actions) {
-      mergedFrontmatter.hero.actions = mergedFrontmatter.hero.actions?.map((action: Record<string, unknown>, i: number) => ({
-        ...action,
-        text: translatedFrontmatter.hero.actions?.[i]?.text || action.text,
-      }));
+      mergedFrontmatter.hero.actions = mergedFrontmatter.hero.actions?.map(
+        (action: Record<string, unknown>, i: number) => ({
+          ...action,
+          text: translatedFrontmatter.hero.actions?.[i]?.text || action.text,
+        }),
+      );
     }
   }
 


### PR DESCRIPTION
Closes #769

Root cause fix — translator was discarding hero.tagline, hero.title, hero.actions translations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)