### PR TITLE
feat(i18n): add cross-repository language persistence

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -1,7 +1,7 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
-import Icon from './Icon.astro';
 import { localizeEcosystemHref } from '../src/utils/localize-ecosystem-href.ts';
+import Icon from './Icon.astro';
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
   title: string;

--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -1,6 +1,7 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
 import Icon from './Icon.astro';
+import { localizeEcosystemHref } from '../src/utils/localize-ecosystem-href.ts';
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
   title: string;
@@ -9,6 +10,10 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
 }
 
 const { title, description, icon, ...attributes } = Astro.props;
+const localeSlug = Astro.currentLocale || '';
+if (attributes.href && localeSlug) {
+  attributes.href = localizeEcosystemHref(String(attributes.href), localeSlug);
+}
 ---
 
 <div class:list={['sl-link-card', { 'has-icon': !!icon }]}>

--- a/config.ts
+++ b/config.ts
@@ -700,9 +700,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
 
   const localeHeadScripts: HeadEntry[] = [];
   if (resolvedLocales) {
-    const langToSlugMap = Object.fromEntries(
-      Object.entries(resolvedLocales).map(([slug, cfg]) => [cfg.lang, slug]),
-    );
+    const langToSlugMap = Object.fromEntries(Object.entries(resolvedLocales).map(([slug, cfg]) => [cfg.lang, slug]));
     const slugSet = JSON.stringify(Object.keys(resolvedLocales));
 
     localeHeadScripts.push({
@@ -755,7 +753,9 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       starlight({
         title,
         plugins: starlightPlugins,
-        head: [...(head as Parameters<typeof starlight>[0]['head'] || []), ...localeHeadScripts] as Parameters<typeof starlight>[0]['head'],
+        head: [...((head as Parameters<typeof starlight>[0]['head']) || []), ...localeHeadScripts] as Parameters<
+          typeof starlight
+        >[0]['head'],
         logo: logo as Parameters<typeof starlight>[0]['logo'],
         ...(resolvedLocales ? { locales: resolvedLocales, defaultLocale: resolvedDefaultLocale } : {}),
         ...(subcategorySidebar

--- a/config.ts
+++ b/config.ts
@@ -698,6 +698,52 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
     options.locales === false ? undefined : options.locales || (hasEnSubdir ? f5xcDefaultLocales : undefined);
   const resolvedDefaultLocale = options.defaultLocale || f5xcDefaultLocale;
 
+  const localeHeadScripts: HeadEntry[] = [];
+  if (resolvedLocales) {
+    const langToSlugMap = Object.fromEntries(
+      Object.entries(resolvedLocales).map(([slug, cfg]) => [cfg.lang, slug]),
+    );
+    const slugSet = JSON.stringify(Object.keys(resolvedLocales));
+
+    localeHeadScripts.push({
+      tag: 'script',
+      content: `
+(function(){
+  try {
+    var m = ${JSON.stringify(langToSlugMap)};
+    var lang = document.documentElement.lang || 'en';
+    var slug = m[lang] || lang.toLowerCase();
+    localStorage.setItem('f5xc-locale', slug);
+  } catch(e) {}
+})();
+`,
+    });
+
+    localeHeadScripts.push({
+      tag: 'script',
+      content: `
+(function(){
+  try {
+    var stored = localStorage.getItem('f5xc-locale');
+    if (!stored || stored === '${resolvedDefaultLocale}') return;
+    if (sessionStorage.getItem('f5xc-locale-redirected')) return;
+    var valid = new Set(${slugSet});
+    if (!valid.has(stored)) return;
+    var base = '${normalizedBase}';
+    var path = window.location.pathname;
+    var afterBase = path.slice(base.length).replace(/^\\/+/, '').replace(/\\/+$/, '');
+    var segments = afterBase ? afterBase.split('/') : [];
+    if (segments.length > 1) return;
+    if (segments[0] === '${resolvedDefaultLocale}') {
+      sessionStorage.setItem('f5xc-locale-redirected', '1');
+      window.location.replace(base + '/' + stored + '/');
+    }
+  } catch(e) {}
+})();
+`,
+    });
+  }
+
   return defineConfig({
     site,
     base,
@@ -709,7 +755,7 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       starlight({
         title,
         plugins: starlightPlugins,
-        head: head as Parameters<typeof starlight>[0]['head'],
+        head: [...(head as Parameters<typeof starlight>[0]['head'] || []), ...localeHeadScripts] as Parameters<typeof starlight>[0]['head'],
         logo: logo as Parameters<typeof starlight>[0]['logo'],
         ...(resolvedLocales ? { locales: resolvedLocales, defaultLocale: resolvedDefaultLocale } : {}),
         ...(subcategorySidebar

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "./src/utils/resolve-icon.ts": "./src/utils/resolve-icon.ts",
     "./src/i18n/locales.ts": "./src/i18n/locales.ts",
     "./src/i18n/translator.ts": "./src/i18n/translator.ts",
-    "./src/i18n/prompt.ts": "./src/i18n/prompt.ts"
+    "./src/i18n/prompt.ts": "./src/i18n/prompt.ts",
+    "./src/utils/localize-ecosystem-href.ts": "./src/utils/localize-ecosystem-href.ts"
   },
   "files": [
     "index.ts",

--- a/src/utils/localize-ecosystem-href.ts
+++ b/src/utils/localize-ecosystem-href.ts
@@ -1,0 +1,45 @@
+const ECOSYSTEM_HOST = 'f5xc-salesdemos.github.io';
+
+const VALID_LOCALE_SLUGS = new Set([
+  'en', 'fr', 'es', 'de', 'pt-br', 'ja', 'ko',
+  'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th',
+]);
+
+const LANG_TO_SLUG: Record<string, string> = {
+  'pt-BR': 'pt-br',
+  'zh-CN': 'zh-cn',
+  'zh-TW': 'zh-tw',
+};
+
+export function langToSlug(lang: string): string {
+  return LANG_TO_SLUG[lang] || lang.toLowerCase();
+}
+
+export function localizeEcosystemHref(
+  href: string,
+  localeSlug: string,
+  ecosystemHost: string = ECOSYSTEM_HOST,
+): string {
+  if (!localeSlug || !VALID_LOCALE_SLUGS.has(localeSlug)) return href;
+
+  let url: URL;
+  try {
+    url = new URL(href);
+  } catch {
+    return href;
+  }
+
+  if (url.hostname !== ecosystemHost) return href;
+
+  const segments = url.pathname.split('/').filter(Boolean);
+  if (segments.length === 0) return href;
+
+  if (segments.length >= 2 && VALID_LOCALE_SLUGS.has(segments[1])) {
+    return href;
+  }
+
+  segments.splice(1, 0, localeSlug);
+  url.pathname = '/' + segments.join('/') + '/';
+
+  return url.toString();
+}

--- a/src/utils/localize-ecosystem-href.ts
+++ b/src/utils/localize-ecosystem-href.ts
@@ -1,8 +1,19 @@
 const ECOSYSTEM_HOST = 'f5xc-salesdemos.github.io';
 
 const VALID_LOCALE_SLUGS = new Set([
-  'en', 'fr', 'es', 'de', 'pt-br', 'ja', 'ko',
-  'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th',
+  'en',
+  'fr',
+  'es',
+  'de',
+  'pt-br',
+  'ja',
+  'ko',
+  'zh-cn',
+  'zh-tw',
+  'ar',
+  'it',
+  'hi',
+  'th',
 ]);
 
 const LANG_TO_SLUG: Record<string, string> = {


### PR DESCRIPTION
## Summary

- Add `localizeEcosystemHref()` utility to inject locale into cross-repo links
- `LinkCard.astro` now localizes ecosystem hrefs at build time using `Astro.currentLocale`
- Two new `<head>` scripts (only when locales are enabled):
  - **Persist script**: saves current locale to `localStorage('f5xc-locale')`
  - **Redirect script**: on repo root landing page, redirects to preferred locale
- External links (console.ves.volterra.io, github.com, etc.) are left unchanged

Companion PR: f5xc-salesdemos/starlight-mega-menu#4 (merged — MegaMenu locale injection)

Closes #774

## Test plan

- [ ] Build docs-theme locally; verify LinkCard links include locale in non-English builds
- [ ] Verify localStorage is written on page load
- [ ] Test arrival redirect: set `localStorage.setItem('f5xc-locale', 'fr')`, navigate to repo root
- [ ] Verify external links remain unchanged
- [ ] Verify repos with `locales: false` don't get the head scripts

🤖 Generated with [Claude Code](https://claude.com/claude-code)