### PR TITLE
fix(i18n): normalize BCP-47 locale codes in LinkCard

### DIFF
--- a/components/LinkCard.astro
+++ b/components/LinkCard.astro
@@ -1,6 +1,6 @@
 ---
 import type { HTMLAttributes } from 'astro/types';
-import { localizeEcosystemHref } from '../src/utils/localize-ecosystem-href.ts';
+import { langToSlug, localizeEcosystemHref } from '../src/utils/localize-ecosystem-href.ts';
 import Icon from './Icon.astro';
 
 interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
@@ -10,7 +10,7 @@ interface Props extends Omit<HTMLAttributes<'a'>, 'title'> {
 }
 
 const { title, description, icon, ...attributes } = Astro.props;
-const localeSlug = Astro.currentLocale || '';
+const localeSlug = langToSlug(Astro.currentLocale || '');
 if (attributes.href && localeSlug) {
   attributes.href = localizeEcosystemHref(String(attributes.href), localeSlug);
 }


### PR DESCRIPTION
## Summary

- Apply `langToSlug()` to `Astro.currentLocale` in LinkCard.astro to normalize BCP-47 codes (pt-BR, zh-CN, zh-TW) to URL slugs before passing to `localizeEcosystemHref()`

## Problem

`Astro.currentLocale` returns BCP-47 codes from `locale.codes[0]`, not URL slugs from `locale.path`. Locales like `fr`, `es`, `de` work because their BCP-47 code equals the URL slug. But `pt-br`, `zh-cn`, `zh-tw` fail because `pt-BR` != `pt-br`.

## Test plan

- [ ] Verify `https://f5xc-salesdemos.github.io/docs/pt-br/` LinkCards include `/pt-br/` in cross-repo hrefs
- [ ] Verify `https://f5xc-salesdemos.github.io/docs/zh-cn/` LinkCards include `/zh-cn/` in cross-repo hrefs
- [ ] Verify `https://f5xc-salesdemos.github.io/docs/fr/` still works (no regression)

Closes #778

🤖 Generated with [Claude Code](https://claude.com/claude-code)