### PR TITLE
fix(i18n): swap locale head script order so redirect runs before persist

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -708,20 +708,6 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       content: `
 (function(){
   try {
-    var m = ${JSON.stringify(langToSlugMap)};
-    var lang = document.documentElement.lang || 'en';
-    var slug = m[lang] || lang.toLowerCase();
-    localStorage.setItem('f5xc-locale', slug);
-  } catch(e) {}
-})();
-`,
-    });
-
-    localeHeadScripts.push({
-      tag: 'script',
-      content: `
-(function(){
-  try {
     var stored = localStorage.getItem('f5xc-locale');
     if (!stored || stored === '${resolvedDefaultLocale}') return;
     if (sessionStorage.getItem('f5xc-locale-redirected')) return;
@@ -736,6 +722,20 @@ export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {
       sessionStorage.setItem('f5xc-locale-redirected', '1');
       window.location.replace(base + '/' + stored + '/');
     }
+  } catch(e) {}
+})();
+`,
+    });
+
+    localeHeadScripts.push({
+      tag: 'script',
+      content: `
+(function(){
+  try {
+    var m = ${JSON.stringify(langToSlugMap)};
+    var lang = document.documentElement.lang || 'en';
+    var slug = m[lang] || lang.toLowerCase();
+    localStorage.setItem('f5xc-locale', slug);
   } catch(e) {}
 })();
 `,


### PR DESCRIPTION
## Summary
- Swaps the order of locale `<head>` scripts so the arrival redirect runs **before** the persist script
- Fixes a race condition where navigating cross-repo (e.g., `/docs/zh-cn/` → `/waf/`) would land the user on `/waf/en/` instead of redirecting to `/waf/zh-cn/`

## Root Cause
The persist script (Layer 1) was injected first in the `<head>`, overwriting `localStorage.f5xc-locale` from `"zh-cn"` to `"en"` before the redirect script (Layer 4) could read the stored preference.

Fixes #781

## Test plan
- [ ] Navigate to `/docs/fr/` → click any cross-repo link → verify localStorage persists `fr`
- [ ] Set `localStorage.f5xc-locale = 'zh-cn'` → navigate to `/waf/` → verify redirect to `/waf/zh-cn/`
- [ ] Verify redirect only fires on root index pages, not deep pages
- [ ] Verify sessionStorage guard prevents redirect loops

🤖 Generated with [Claude Code](https://claude.com/claude-code)