### PR TITLE
fix(i18n): wrap autogenerate sidebar entries in groups for translation support

### DIFF
--- a/src/utils/subcategory-sidebar.ts
+++ b/src/utils/subcategory-sidebar.ts
@@ -196,9 +196,9 @@ export function buildSubcategorySidebar(contentDir: string): SidebarItem[] | und
       const translations = sidebarTranslations[label as keyof typeof sidebarTranslations];
       sidebar.push({
         label,
-        autogenerate: { directory: dir },
         collapsed: false,
         ...(translations ? { translations } : {}),
+        items: [{ autogenerate: { directory: dir } }],
       });
     }
 


### PR DESCRIPTION
## Summary
- Starlight ignores `translations` on top-level `autogenerate` sidebar entries
- Wrap each autogenerate in a group with `items` array so translated group labels display correctly on localized pages
- One-line change: `autogenerate: { directory: dir }` moves inside `items: [...]`

## Test plan
- [ ] Navigate to `/vscode-f5xc-tools/pt-br/` — sidebar groups show "Configuração", "Funcionalidades", "Primeiros Passos", "Referência"
- [ ] English pages still show proper Title Case labels

Fixes #784

🤖 Generated with [Claude Code](https://claude.com/claude-code)