### PR TITLE
fix(i18n): translate site title for non-English locales

### DIFF
--- a/route-middleware.ts
+++ b/route-middleware.ts
@@ -1,5 +1,8 @@
 import type { StarlightRouteData } from '@astrojs/starlight/route-data';
 import { defineRouteMiddleware } from '@astrojs/starlight/route-data';
+import { itemLabels, menuLabels } from './src/i18n/mega-menu-translations.ts';
+
+const titleTranslations: Record<string, Record<string, string>> = { ...menuLabels, ...itemLabels };
 
 type SidebarEntry = StarlightRouteData['sidebar'][number];
 
@@ -59,6 +62,11 @@ export const onRequest = defineRouteMiddleware(async (context, next) => {
 
   if (indexSlugs.size > 0) {
     route.sidebar = filterIndexPages(route.sidebar, indexSlugs);
+  }
+
+  if (route.lang && route.lang !== 'en') {
+    const translated = titleTranslations[route.siteTitle]?.[route.lang];
+    if (translated) route.siteTitle = translated;
   }
 
   await next();


### PR DESCRIPTION
## Summary
- Translate `route.siteTitle` in the route middleware using existing mega-menu translations (`menuLabels` + `itemLabels`)
- Fixes site title and breadcrumb showing English on non-English locale pages (e.g., "Demo Resources" on `/ko/`)
- All 22 repo titles verified to have translations for all 12 non-English locales

Closes #791

## Test plan
- [ ] Lint passes (`npx biome check route-middleware.ts`)
- [ ] Navigate to `f5xc-salesdemos.github.io/demo-resources/ko/` — title should show "데모 리소스"
- [ ] Navigate to `f5xc-salesdemos.github.io/waf/fr/` — title should show "Pare-feu applicatif (WAF)"
- [ ] English pages remain unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)