### PR TITLE
feat: add glossary support to translation pipeline

### DIFF
--- a/bin/translate.mjs
+++ b/bin/translate.mjs
@@ -7,6 +7,7 @@ import path from 'node:path';
 async function main() {
   const args = process.argv.slice(2);
   const staged = args.includes('--staged');
+  const force = args.includes('--force');
   const localeFlag = args.indexOf('--locale');
   const singleLocale = localeFlag !== -1 ? args[localeFlag + 1] : null;
 
@@ -73,6 +74,7 @@ async function main() {
         const result = await translateFile(filePath, code, config.label, {
           apiKey,
           contentDir: resolvedContentDir,
+          force,
         });
         if (result) {
           translated.push(result);

--- a/src/i18n/glossary.ts
+++ b/src/i18n/glossary.ts
@@ -1,0 +1,18 @@
+import { categoryTitles, itemLabels, menuLabels } from './mega-menu-translations.ts';
+
+const allTerms: Record<string, Record<string, string>> = {
+  ...menuLabels,
+  ...categoryTitles,
+  ...itemLabels,
+};
+
+export function getGlossary(localeCode: string): Record<string, string> {
+  const result: Record<string, string> = {};
+  for (const [english, translations] of Object.entries(allTerms)) {
+    const translated = translations[localeCode];
+    if (translated && translated !== english) {
+      result[english] = translated;
+    }
+  }
+  return result;
+}

--- a/src/i18n/prompt.ts
+++ b/src/i18n/prompt.ts
@@ -1,4 +1,19 @@
-export function buildTranslationPrompt(targetLang: string, targetCode: string): string {
+export function buildTranslationPrompt(
+  targetLang: string,
+  targetCode: string,
+  glossary?: Record<string, string>,
+): string {
+  let glossaryBlock = '';
+  if (glossary && Object.keys(glossary).length > 0) {
+    const entries = Object.entries(glossary)
+      .map(([en, translated]) => `  "${en}" → "${translated}"`)
+      .join('\n');
+    glossaryBlock = `
+
+Mandatory terminology — use these exact translations whenever the English term appears in prose (headings, paragraphs, list items). Do NOT paraphrase or leave them in English:
+${entries}`;
+  }
+
   return `You are a professional technical documentation translator. Translate the following MDX documentation content from English to ${targetLang} (${targetCode}).
 
 Rules:
@@ -11,5 +26,5 @@ Rules:
 - Use formal register appropriate for technical documentation in ${targetLang}
 - ALWAYS translate the title and sidebar.label to ${targetLang} — never keep them in English, even for technical terms like "Trigger Detection", "FAQ", "Console", "Diagnostics"
 - Do NOT add, remove, or reorder any content — the output must be structurally identical to the input
-- Return ONLY the translated document with no commentary, no markdown fences wrapping the output`;
+- Return ONLY the translated document with no commentary, no markdown fences wrapping the output${glossaryBlock}`;
 }

--- a/src/i18n/translator.ts
+++ b/src/i18n/translator.ts
@@ -2,12 +2,14 @@ import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
 import matter from 'gray-matter';
+import { getGlossary } from './glossary.ts';
 import { buildTranslationPrompt } from './prompt.ts';
 
 export interface TranslateOptions {
   apiKey: string;
   model?: string;
   contentDir: string;
+  force?: boolean;
 }
 
 export function computeSourceHash(content: string): string {
@@ -40,14 +42,15 @@ export async function translateFile(
   const relativePath = path.relative(path.join(options.contentDir, 'en'), englishPath);
   const targetPath = path.join(options.contentDir, localeCode, relativePath);
 
-  if (!needsTranslation(englishRaw, targetPath)) {
+  if (!options.force && !needsTranslation(englishRaw, targetPath)) {
     return null;
   }
 
   const { default: Anthropic } = await import('@anthropic-ai/sdk');
   const client = new Anthropic({ apiKey: options.apiKey });
 
-  const systemPrompt = buildTranslationPrompt(localeName, localeCode);
+  const glossary = getGlossary(localeCode);
+  const systemPrompt = buildTranslationPrompt(localeName, localeCode, glossary);
   const sourceLength = englishRaw.length;
 
   let translated: string;


### PR DESCRIPTION
## Summary
- Adds `src/i18n/glossary.ts` that extracts per-locale product term mappings from `mega-menu-translations.ts`
- Modifies `prompt.ts` to inject mandatory terminology block into the translation system prompt
- Adds `--force` flag to `translator.ts` and `translate.mjs` to re-translate files even when English source hash is unchanged

Closes #796

## Why
Machine-translated content has inconsistent product name translations across repos. For example, Japanese pages show English "Web Application Firewall" in some files but correctly translated "Webアプリケーションファイアウォール" in others. The glossary ensures all 12 locales use authoritative translations from the mega-menu for F5 product names.

## Test plan
- [ ] `npx @biomejs/biome check` passes on all modified files
- [ ] Run `docs-translate --force --locale ja` on a content repo to verify glossary terms appear in translated output
- [ ] Verify translated files contain Japanese product names from glossary instead of English originals

🤖 Generated with [Claude Code](https://claude.com/claude-code)