### PR TITLE
fix: update default translator model to claude-sonnet-4-6

### DIFF
--- a/src/i18n/translator.ts
+++ b/src/i18n/translator.ts
@@ -61,7 +61,7 @@ export async function translateFile(
     attempts++;
     try {
       const stream = client.messages.stream({
-        model: options.model || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-20250514',
+        model: options.model || process.env.ANTHROPIC_MODEL || 'claude-sonnet-4-6',
         max_tokens: Math.max(4096, Math.ceil(sourceLength * 2.5)),
         system: systemPrompt,
         messages: [{ role: 'user', content: englishRaw }],


### PR DESCRIPTION
## Summary
- Updates default translator model from deprecated `claude-sonnet-4-20250514` to `claude-sonnet-4-6`

Closes #797

## Why
The F5 AI proxy rejects the old model ID with a 400 error. The short ID `claude-sonnet-4-6` is accepted.

## Test plan
- [ ] Run `docs-translate --force --locale ja` against a content repo — translations succeed

🤖 Generated with [Claude Code](https://claude.com/claude-code)