### PR TITLE
chore: add starlight-mega-menu/ to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -191,3 +191,4 @@ pi-*.html
 packages/coding-agent/src/internal-urls/docs-index.generated.ts
 packages/coding-agent/src/internal-urls/build-info.generated.ts
 packages/typescript-edit-benchmark/runs/
+starlight-mega-menu/


### PR DESCRIPTION
Adds `starlight-mega-menu/` to `.gitignore` — this is a locally cloned development repo that should not be tracked by the parent.

Closes #910