### PR TITLE
fix: lowercase autogenerated sidebar slugs to match Starlight entries

### DIFF
--- a/src/utils/subcategory-sidebar.test.ts
+++ b/src/utils/subcategory-sidebar.test.ts
@@ -6,9 +6,7 @@ describe('filePathToSlug', () => {
     // Regression: a capitalised directory (e.g. "Enhancements/") previously
     // produced a sidebar slug that matched no (lowercased) content entry,
     // failing the Starlight build with "slug does not exist".
-    expect(filePathToSlug('Enhancements/healthcheck-enhancements.mdx')).toBe(
-      '/enhancements/healthcheck-enhancements/',
-    );
+    expect(filePathToSlug('Enhancements/healthcheck-enhancements.mdx')).toBe('/enhancements/healthcheck-enhancements/');
   });
 
   it('leaves already-lowercase paths unchanged', () => {

--- a/src/utils/subcategory-sidebar.test.ts
+++ b/src/utils/subcategory-sidebar.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest';
+import { filePathToSlug } from './subcategory-sidebar';
+
+describe('filePathToSlug', () => {
+  it('lowercases capitalised path segments to match Starlight entry slugs', () => {
+    // Regression: a capitalised directory (e.g. "Enhancements/") previously
+    // produced a sidebar slug that matched no (lowercased) content entry,
+    // failing the Starlight build with "slug does not exist".
+    expect(filePathToSlug('Enhancements/healthcheck-enhancements.mdx')).toBe(
+      '/enhancements/healthcheck-enhancements/',
+    );
+  });
+
+  it('leaves already-lowercase paths unchanged', () => {
+    expect(filePathToSlug('resources/api_crawler.md')).toBe('/resources/api_crawler/');
+    expect(filePathToSlug('guides/getting-started.md')).toBe('/guides/getting-started/');
+  });
+
+  it('maps index files to the root slug', () => {
+    expect(filePathToSlug('index.md')).toBe('/');
+    expect(filePathToSlug('section/index.mdx')).toBe('/section/');
+  });
+
+  it('normalises backslashes to forward slashes', () => {
+    expect(filePathToSlug('Enhancements\\foo.mdx')).toBe('/enhancements/foo/');
+  });
+});

--- a/src/utils/subcategory-sidebar.ts
+++ b/src/utils/subcategory-sidebar.ts
@@ -83,11 +83,15 @@ function kebabToTitleCase(kebab: string): string {
  *      "guides/getting-started.md" → "/guides/getting-started/"
  *      "index.md" → "/"
  */
-function filePathToSlug(relativePath: string): string {
+export function filePathToSlug(relativePath: string): string {
   const normalized = relativePath
     .replace(/\\/g, '/')
     .replace(/\.mdx?$/, '')
-    .replace(/\/index$/, '');
+    .replace(/\/index$/, '')
+    // Starlight lowercases content-entry slugs, so the sidebar slug must be
+    // lowercased too — otherwise a capitalised path segment (e.g. "Enhancements/")
+    // produces a sidebar slug that matches no entry and fails the build.
+    .toLowerCase();
 
   if (normalized === 'index' || normalized === '') return '/';
   return `/${normalized}/`;


### PR DESCRIPTION
Closes #857

## Problem

The **GitHub Pages Deploy** fails for any consuming repo with a capitalised top-level docs directory. `filePathToSlug` (`src/utils/subcategory-sidebar.ts`) builds the autogenerated sidebar `slug` from the content file path **without lowercasing**, but Starlight lowercases content-entry slugs — so `Enhancements/healthcheck-enhancements` (the only capitalised dir, in api-specs-enriched) matches no entry:

```
AstroUserError: The slug "Enhancements/healthcheck-enhancements" specified in the Starlight sidebar config does not exist.
```

(Failing since ~06-18, when Starlight tightened slug validation.)

## Fix

One line: lowercase the slug in `filePathToSlug` so it matches Starlight's lowercased entries (a no-op for the already-lowercase dirs — every other docs dir). Plus a unit regression test (`filePathToSlug` exported for direct testing).

## Verification

- `vitest run`: **25 pass** (4 new in `subcategory-sidebar.test.ts`, covering the capitalised-dir regression, already-lowercase no-op, index, and backslash normalisation).

Root-cause fix in the shared theme so no capitalised directory breaks the build again — rather than renaming the one offending dir downstream.

🤖 Generated with [Claude Code](https://claude.com/claude-code)