### PR TITLE
feat: add xcsh Chrome Extension to mega-menu + federated search

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -489,6 +489,14 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               href: 'https://f5xc-salesdemos.github.io/xcsh/',
               icon: resolveIcon('carbon:terminal'),
             },
+            {
+              label: 'xcsh Chrome Extension',
+              translations: itemLabels['xcsh Chrome Extension'],
+              description: 'Drive the F5 XC console with xcsh',
+              descriptionTranslations: itemDescriptions['Drive the F5 XC console with xcsh'],
+              href: 'https://f5xc-salesdemos.github.io/xcsh-chrome-extension/',
+              icon: resolveIcon('carbon:application-web'),
+            },
           ],
         },
       ],
@@ -566,6 +574,7 @@ const federatedSearchSites = [
   { repo: 'origin-server', label: 'Origin Server' },
   { repo: 'traffic-generator', label: 'Traffic Generator' },
   { repo: 'demo-resources', label: 'Demo Resources' },
+  { repo: 'xcsh-chrome-extension', label: 'xcsh Chrome Extension' },
 ];
 
 export function createF5xcDocsConfig(options: F5xcDocsConfigOptions = {}) {

--- a/src/i18n/mega-menu-translations.ts
+++ b/src/i18n/mega-menu-translations.ts
@@ -689,6 +689,20 @@ export const itemDescriptions: Record<string, I18nString> = {
     hi: 'F5 XC के लिए AI-संचालित CLI',
     th: 'CLI ที่ขับเคลื่อนด้วย AI สำหรับ F5 XC',
   },
+  'Drive the F5 XC console with xcsh': {
+    fr: 'Pilotez la console F5 XC avec xcsh',
+    es: 'Controla la consola de F5 XC con xcsh',
+    de: 'Steuern Sie die F5 XC-Konsole mit xcsh',
+    'pt-BR': 'Controle o console do F5 XC com o xcsh',
+    ja: 'xcsh で F5 XC コンソールを操作',
+    ko: 'xcsh로 F5 XC 콘솔 제어',
+    'zh-CN': '使用 xcsh 驱动 F5 XC 控制台',
+    'zh-TW': '使用 xcsh 驅動 F5 XC 主控台',
+    ar: 'تحكم في وحدة تحكم F5 XC باستخدام xcsh',
+    it: 'Controlla la console F5 XC con xcsh',
+    hi: 'xcsh के साथ F5 XC कंसोल चलाएं',
+    th: 'ควบคุมคอนโซล F5 XC ด้วย xcsh',
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -1303,5 +1317,19 @@ export const itemLabels: Record<string, I18nString> = {
     it: 'xcsh CLI',
     hi: 'xcsh CLI',
     th: 'xcsh CLI',
+  },
+  'xcsh Chrome Extension': {
+    fr: 'Extension Chrome xcsh',
+    es: 'Extensión de Chrome xcsh',
+    de: 'xcsh Chrome-Erweiterung',
+    'pt-BR': 'Extensão do Chrome xcsh',
+    ja: 'xcsh Chrome 拡張機能',
+    ko: 'xcsh Chrome 확장',
+    'zh-CN': 'xcsh Chrome 扩展',
+    'zh-TW': 'xcsh Chrome 擴充功能',
+    ar: 'إضافة xcsh لمتصفح Chrome',
+    it: 'Estensione Chrome xcsh',
+    hi: 'xcsh Chrome एक्सटेंशन',
+    th: 'ส่วนขยาย Chrome ของ xcsh',
   },
 };


### PR DESCRIPTION
Adds xcsh-chrome-extension to the Developer Tools mega-menu category, federated search, and i18n translations (13 locales). Closes #863.

🤖 Generated with [Claude Code](https://claude.com/claude-code)