### PR TITLE
feat(deps): widen astro peer to >=6.0.0 for astro 7 support

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
     "@iconify-json/mdi": "*",
     "@iconify-json/ph": "*",
     "@iconify-json/tabler": "*",
-    "astro": "^6.1.9"
+    "astro": ">=6.0.0"
   },
   "peerDependenciesMeta": {
     "@iconify-json/lucide": {


### PR DESCRIPTION
Closes #887

Widen `peerDependencies.astro` from `^6.1.9` to `>=6.0.0`, so consumers (docs-builder) can use astro 7+ without an npm override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)