### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -31,7 +31,7 @@ updates:
     groups:
       # First-party @f5xc-salesdemos/* packages: track latest daily, all update types
       # (auto-merged once CI is green) so internal deps never drift behind.
-      f5xc-internal:
+      f5-internal:
         patterns:
           - "@f5xc-salesdemos/*"
         update-types:


### PR DESCRIPTION
Closes #890

Synced managed files from `f5xc-salesdemos/docs-control` canonical source:

- .github/dependabot.yml