### PR TITLE
fix: final org rename sweep

### DIFF
--- a/components/Banner.astro
+++ b/components/Banner.astro
@@ -1,7 +1,7 @@
 ---
 import Default from '@astrojs/starlight/components/Banner.astro';
 
-const docsHome = process.env.DOCS_HOME || 'https://f5xc-salesdemos.github.io/docs/';
+const docsHome = process.env.DOCS_HOME || 'https://f5-sales-demo.github.io/docs/';
 const { sidebar, entry, siteTitle, editUrl } = Astro.locals.starlightRoute;
 const t = Astro.locals.t;
 

--- a/components/Icon.astro
+++ b/components/Icon.astro
@@ -40,13 +40,13 @@ if (isScoped) {
       iconData = (await import('@iconify-json/tabler/icons.json')).default;
       break;
     case 'f5-brand':
-      iconData = (await import('@f5xc-salesdemos/icons-f5-brand/icons.json')).default;
+      iconData = (await import('@f5-sales-demo/icons-f5-brand/icons.json')).default;
       break;
     case 'f5xc':
-      iconData = (await import('@f5xc-salesdemos/icons-f5xc/icons.json')).default;
+      iconData = (await import('@f5-sales-demo/icons-f5xc/icons.json')).default;
       break;
     case 'hashicorp-flight':
-      iconData = (await import('@f5xc-salesdemos/icons-hashicorp-flight/icons.json')).default;
+      iconData = (await import('@f5-sales-demo/icons-hashicorp-flight/icons.json')).default;
       break;
     default:
       throw new Error(

--- a/components/SiteTitle.astro
+++ b/components/SiteTitle.astro
@@ -2,7 +2,7 @@
 import config from 'virtual:starlight/user-config';
 import { logos } from 'virtual:starlight/user-images';
 
-const docsHome = process.env.DOCS_HOME || 'https://f5xc-salesdemos.github.io/docs/';
+const docsHome = process.env.DOCS_HOME || 'https://f5-sales-demo.github.io/docs/';
 const { siteTitle } = Astro.locals.starlightRoute;
 ---
 


### PR DESCRIPTION
Closes #898

Exhaustive audit — last remaining old org references.

🤖 Generated with [Claude Code](https://claude.com/claude-code)