### PR TITLE
fix: point mega-menu at renamed xcsh repos (#943)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -315,7 +315,7 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               translations: itemLabels['Terraform Provider'],
               description: 'F5 XC Terraform provider',
               descriptionTranslations: itemDescriptions['F5 XC Terraform provider'],
-              href: 'https://f5-sales-demo.github.io/terraform-provider-f5xc/',
+              href: 'https://f5-sales-demo.github.io/terraform-provider-xcsh/',
               icon: resolveIcon('hashicorp-flight:terraform-color'),
             },
             {
@@ -486,7 +486,7 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               translations: itemLabels['VS Code Extension'],
               description: 'Manage F5 XC resources from VS Code',
               descriptionTranslations: itemDescriptions['Manage F5 XC resources from VS Code'],
-              href: 'https://f5-sales-demo.github.io/vscode-f5xc-tools/',
+              href: 'https://f5-sales-demo.github.io/vscode-xcsh/',
               icon: resolveIcon('carbon:code'),
             },
             {

--- a/src/utils/subcategory-sidebar.ts
+++ b/src/utils/subcategory-sidebar.ts
@@ -53,9 +53,9 @@ function collectMarkdownFiles(dir: string): string[] {
 
 /**
  * Clean a page_title to match Terraform Registry sidebar labels.
- * Resources:    "f5xc_http_loadbalancer Resource - terraform-provider-f5xc" → "f5xc_http_loadbalancer"
- * Data Sources: "f5xc_http_loadbalancer Data Source - terraform-provider-f5xc" → "f5xc_http_loadbalancer"
- * Functions:    "blindfold function - terraform-provider-f5xc" → "blindfold"
+ * Resources:    "f5xc_http_loadbalancer Resource - terraform-provider-xcsh" → "f5xc_http_loadbalancer"
+ * Data Sources: "f5xc_http_loadbalancer Data Source - terraform-provider-xcsh" → "f5xc_http_loadbalancer"
+ * Functions:    "blindfold function - terraform-provider-xcsh" → "blindfold"
  * Guides:       "Guide: HTTP Load Balancer with Security Features" → "HTTP Load Balancer with Security Features"
  */
 function cleanPageTitle(pageTitle: string, docType: DocType): string {


### PR DESCRIPTION
## Summary

The shared mega-menu linked to two **pre-rename** repos that now 404:

| Was (404) | Now (200) |
|---|---|
| `vscode-f5xc-tools` | `vscode-xcsh` |
| `terraform-provider-f5xc` | `terraform-provider-xcsh` |

- `config.ts:318` / `config.ts:489` — corrected the two `github.io` hrefs.
- `src/utils/subcategory-sidebar.ts` — refreshed stale `terraform-provider-*` comment examples (the parsing regex is generic; no behavior change).

## Verification

- `grep -rn 'vscode-f5xc-tools\|terraform-provider-f5xc' .` → **0**
- `npm test` → **25 passed**
- Live: old URLs return 404, `vscode-xcsh` / `terraform-provider-xcsh` return 200.

⚠️ **Note:** `config.ts` drives the mega-menu on every downstream site via `createF5xcDocsConfig()`. This reaches live sites only after a **docs-theme release + downstream rebuild**.

Fixes #943