### PR TITLE
fix: do not localize single-locale ecosystem links (#945)

### DIFF
--- a/src/utils/localize-ecosystem-href.test.ts
+++ b/src/utils/localize-ecosystem-href.test.ts
@@ -62,4 +62,14 @@ describe('localizeEcosystemHref', () => {
     const result = localizeEcosystemHref('https://custom.host.io/waf/', 'fr', 'custom.host.io');
     expect(result).toBe('https://custom.host.io/waf/fr/');
   });
+
+  it('does not localize single-locale ecosystem sites (would 404)', () => {
+    // These sites have no /<locale>/ path; injecting one produces a 404.
+    expect(localizeEcosystemHref('https://f5-sales-demo.github.io/terraform-provider-xcsh/', 'fr')).toBe(
+      'https://f5-sales-demo.github.io/terraform-provider-xcsh/',
+    );
+    expect(localizeEcosystemHref('https://f5-sales-demo.github.io/docs-control/', 'ja')).toBe(
+      'https://f5-sales-demo.github.io/docs-control/',
+    );
+  });
 });

--- a/src/utils/localize-ecosystem-href.ts
+++ b/src/utils/localize-ecosystem-href.ts
@@ -2,6 +2,11 @@ import { bcp47ToSlug, VALID_SLUGS } from '@f5-sales-demo/i18n-core';
 
 const ECOSYSTEM_HOST = 'f5-sales-demo.github.io';
 
+// Ecosystem sites published as a single locale (no `/<locale>/` path segment).
+// Injecting a locale slug into links to these produces a 404
+// (e.g. `/terraform-provider-xcsh/en/`), so they are left unlocalized.
+const NON_LOCALIZED_ECOSYSTEM_SLUGS = new Set(['terraform-provider-xcsh', 'docs-control']);
+
 export const langToSlug = bcp47ToSlug;
 
 export function localizeEcosystemHref(
@@ -22,6 +27,8 @@ export function localizeEcosystemHref(
 
   const segments = url.pathname.split('/').filter(Boolean);
   if (segments.length === 0) return href;
+
+  if (NON_LOCALIZED_ECOSYSTEM_SLUGS.has(segments[0])) return href;
 
   if (segments.length >= 2 && VALID_SLUGS.has(segments[1])) {
     return href;


### PR DESCRIPTION
## Summary

`localizeEcosystemHref` (used by `LinkCard.astro`) appended the current locale to every ecosystem link, so LinkCards pointing at **single-locale** sites 404'd:

- `/terraform-provider-xcsh/en/` → 404 (root `/terraform-provider-xcsh/` is 200)
- `/docs-control/en/` → 404

Added a `NON_LOCALIZED_ECOSYSTEM_SLUGS` guard so those hrefs are returned unlocalized. Multi-locale sites (waf, xcsh, …) are unaffected.

Found via a live link-crawl of the published GitHub Pages sites.

## Verification

- `npm test` → **26 passed** (added 1 test covering the guard, confirmed red→green).
- Post-merge (after release + downstream rebuild): the Terraform Provider / docs-control cards resolve 200.

Note: the unused duplicate at `starlight-mega-menu/libs/localize-ecosystem-href.ts` is tracked separately.

Fixes #945