### PR TITLE
fix(ci): pass release tag through env in downstream dispatch

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -17,8 +17,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Verify npm package version exists
+        env:
+          # A release tag name is caller-supplied text, so interpolating it into the
+          # run body would let it expand into executable shell. Through env it is
+          # inert data that bash only ever reads as a variable.
+          TAG: ${{ github.event.release.tag_name }}
         run: |
-          TAG="${{ github.event.release.tag_name }}"
           VERSION="${TAG#v}"
           echo "Checking npm for @f5-sales-demo/docs-theme@${VERSION}..."
           for i in 1 2 3 4 5; do


### PR DESCRIPTION
## Problem

The scheduled Workflow Security Audit (docs-control#775) fails on this repo with one
high-confidence template injection:

```
error[template-injection] @ .github/workflows/dispatch-downstream.yml:21:20
   TAG="${{ github.event.release.tag_name }}"
```

This is a real vector rather than a theoretical one. The workflow triggers on
`release: published`, and a release tag name is caller-supplied text, so it was expanding
into the `run:` body as shell before bash ever parsed the script.

## Change

`TAG` is bound at step scope through `env:` and read as an ordinary shell variable, so the
tag arrives as inert data.

Left alone deliberately: line 41 passes the same value into `client-payload` of
`peter-evans/repository-dispatch`. That is a `with:` input rather than a `run:` body, so it
is not a shell-injection path and zizmor does not flag it. It is worth a separate look at
some point — a tag containing a double quote would malform that JSON — but that is a
correctness question, not this security fix, and bundling it here would widen the change
beyond the audit finding.

## Verification

Run with zizmor **1.25.2**, the version super-linter pins. This matters: 1.28.x rates
several classes lower, so a local 1.28 run at `--min-severity medium` can pass while CI
still fails. Exit status captured by redirect, not through a pipe.

| | exit | findings |
|---|---|---|
| before | 14 | 1 high |
| after | **0** | **none, any severity** |

`actionlint` clean.

Closes #1003
