### PR TITLE
fix: derive the locale list from i18n-core instead of hardcoding it

### DIFF
--- a/scripts/audit-translations.ts
+++ b/scripts/audit-translations.ts
@@ -2,10 +2,11 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { DEFAULT_LOCALE, SLUG_LIST } from '@f5-sales-demo/i18n-core';
 import matter from 'gray-matter';
 
 const ECOSYSTEM_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const LOCALES = ['fr', 'es', 'de', 'pt-br', 'ja', 'ko', 'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th'];
+const LOCALES = SLUG_LIST.filter((slug) => slug !== DEFAULT_LOCALE);
 
 interface Issue {
   repo: string;

--- a/scripts/fix-translations.ts
+++ b/scripts/fix-translations.ts
@@ -2,10 +2,11 @@
 import { createHash } from 'node:crypto';
 import fs from 'node:fs';
 import path from 'node:path';
+import { DEFAULT_LOCALE, SLUG_LIST } from '@f5-sales-demo/i18n-core';
 import matter from 'gray-matter';
 
 const ECOSYSTEM_ROOT = path.resolve(import.meta.dirname, '..', '..');
-const LOCALES = ['fr', 'es', 'de', 'pt-br', 'ja', 'ko', 'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th'];
+const LOCALES = SLUG_LIST.filter((slug) => slug !== DEFAULT_LOCALE);
 const CONCURRENCY = 8;
 
 const LOCALE_NAMES: Record<string, string> = {


### PR DESCRIPTION
Closes #1009

## Problem

`scripts/audit-translations.ts` and `scripts/fix-translations.ts` each declared:

```ts
const LOCALES = ['fr', 'es', 'de', 'pt-br', 'ja', 'ko', 'zh-cn', 'zh-tw', 'ar', 'it', 'hi', 'th'];
```

That duplicates data `@f5-sales-demo/i18n-core` already owns — and which this repository **already depends on** (`^1.0.0`). Add a locale to the registry and both scripts keep auditing the old set, silently.

## The subtlety that makes this more than a find-and-replace

`SLUG_LIST` contains **13** slugs *including* `en`; these scripts cover the **12 translation targets** and must exclude the source language. So the filter is load-bearing:

```ts
const LOCALES = SLUG_LIST.filter((slug) => slug !== DEFAULT_LOCALE);
```

Without it, both scripts would begin auditing English translations of English.

I verified equivalence by **running** the derivation, not by reading it:

```
before (12): fr es de pt-br ja ko zh-cn zh-tw ar it hi th
after  (12): fr es de pt-br ja ko zh-cn zh-tw ar it hi th
IDENTICAL (same values, same order): true
```

## Why now

This unblocks wiring `scripts/locale-lint.sh` into the fleet lint gate. That check is distributed to every governed repository but **executed by no workflow or hook** — an inert check, which is worse than none because it implies the rule is enforced.

Measuring it across all 38 governed repositories flagged exactly two: this repository (genuine, fixed here) and `i18n-core` itself, where it flags `src/display-names.ts` — the canonical definition it tells everyone else to import. That false positive is being fixed in docs-control. Enforcement is deliberately sequenced *after* this merges, so no repository's gate turns red.

## Verification

- Equivalence proven by execution, as above.
- `bash scripts/locale-lint.sh` → `PASS` in this repository (was `FAIL`).
- `pre-commit run` on both files: all hooks pass.
- Diff is two files, imports only.

Note on the `noNonNullAssertion` warnings Biome reports in these files: they are **pre-existing on `main`** (4 of them, confirmed against the unmodified tree) and are *warnings*, so `biome ci .` exits 0. Untouched here — out of scope for this change. My own first attempt did add two real errors by putting the new import after `gray-matter` instead of in sorted order; Biome's own safe fix corrected that before commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)