### PR TITLE
fix(deps): bump starlight-llms-txt to 1.4.0 for locale-complete llms.txt

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@anthropic-ai/sdk": "^0.115.0",
         "@astrojs/react": "^6.0.0",
         "@f5-sales-demo/i18n-core": "^1.0.0",
-        "@f5-sales-demo/starlight-llms-txt": "1.3.1",
+        "@f5-sales-demo/starlight-llms-txt": "1.4.0",
         "@f5-sales-demo/starlight-mega-menu": "^2.0.0",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
@@ -1694,9 +1694,9 @@
       "license": "Apache-2.0"
     },
     "node_modules/@f5-sales-demo/starlight-llms-txt": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/@f5-sales-demo/starlight-llms-txt/-/starlight-llms-txt-1.3.1.tgz",
-      "integrity": "sha512-5vg//CZZqKBg9V1oEObUgQ1zKJg7aN+nu/kyazYk5AOCwk3ZoYOZ/9EmhVOzwEhOZGwYzy6YcDsAihHUbOlJLg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/@f5-sales-demo/starlight-llms-txt/-/starlight-llms-txt-1.4.0.tgz",
+      "integrity": "sha512-DcGXXMr874Swpi+Q3SfilLBY/xTeDJ+u5XI4FPVJYOt2r2LO6t7eTUcFcsJSzUIfJIKWmZasa7H+ieM8dOdneQ==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^5.0.3",

--- a/package.json
+++ b/package.json
@@ -118,7 +118,7 @@
     "@anthropic-ai/sdk": "^0.115.0",
     "@astrojs/react": "^6.0.0",
     "@f5-sales-demo/i18n-core": "^1.0.0",
-    "@f5-sales-demo/starlight-llms-txt": "1.3.1",
+    "@f5-sales-demo/starlight-llms-txt": "1.4.0",
     "@f5-sales-demo/starlight-mega-menu": "^2.0.0",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",


### PR DESCRIPTION
Closes #1037

## Why

1.3.1 generates the llms.txt surface for the default locale only. Measured on the
live 13-locale `mcn` site: HTML and per-page `.md` variants complete in all 13
locales, but `<locale>/llms.txt` and `_llms-txt/<locale>/…` **404 in all 12**
non-default locales, and the root `llms-full.txt` contained zero non-Latin
characters. The translated `llms-full.txt` documents existed and nothing linked to
them, so a non-default-locale agent had one ~600 KB file and no progressive path.

1.4.0 (`starlight-llms-txt` #338, closes #337) adds `/[locale]/llms.txt` for every
routable locale, extends the `_llms-txt/` tiers to every locale, and lists the
other languages from the root index.

## Why this pin, and not docs-builder

The baked entrypoint is `astro.config.mjs` →
`import { createF5xcDocsConfig } from '@f5-sales-demo/docs-theme/config'`. That
module lives inside `node_modules/@f5-sales-demo/docs-theme/` and is what imports
the plugin, and Node resolves nested-first — so **this exact pin** decides the
version every consuming docs site runs.

I tried the bump in `docs-builder` first and it was a silent no-op: raising the
range there produced a hoisted 1.4.0 *plus* a nested 1.3.1 under `docs-theme`, and
the build would have gone green still running 1.3.1. Closed as misdirected in
f5-sales-demo/docs-builder#866. No change is needed there — its `build-image`
workflow runs `npm install @f5-sales-demo/docs-theme@latest` unconditionally on
every trigger, and a release here dispatches `rebuild-image` to it.

## Why the lockfile is edited by hand

Regenerating it was destructive:

| command | result |
|---|---|
| `npm install --package-lock-only` | ERESOLVE (the plugin's `@astrojs/mdx@^5` peer-requires astro ^6; this tree is on astro 7 — pre-existing) |
| `npm install --package-lock-only --legacy-peer-deps` | **282 entries removed, 5,793 deletions** — whole subtrees dropped |

1.3.1 and 1.4.0 declare **identical** `dependencies` and `peerDependencies`
(checked against the registry), so the transitive graph does not move and only
three fields need to change. The diff is 5 lines.

## Verification

- `package.json`, the lockfile's root dependency entry, and the lockfile's package
  entry all read `1.4.0`, and `resolved` points at the 1.4.0 tarball — asserted
  programmatically, `CONSISTENT`.
- The `integrity` value was verified by downloading the published tarball and
  computing its sha512: `sha512-DcGXXMr874Swpi+Q3SfilLBY/…` matches.
- The tarball genuinely contains the new routes: `package/llms-locale.txt.ts`,
  `package/llms-index.ts`, `package/locales.ts`.
- `config.ts` needs no change — 1.4.0 adds no options and alters no existing ones.
- 1.4.0 was exercised before release by rebuilding the real `mcn` docs (43 pages ×
  13 locales) through the container recipe with the plugin swapped in:
  13/13 locale indexes, 51 tiered files per locale (676 total), each language's
  deepest tier in its own script, no duplicated default-locale documents, no
  `/root/…` routes. A single-locale site emits no locale routes at all.