### PR TITLE
docs: normalize Markdown formatting

### DIFF
--- a/docs/en/astro-config.mdx
+++ b/docs/en/astro-config.mdx
@@ -40,7 +40,7 @@ interface F5xcDocsConfigOptions {
 ```
 
 | Option | Default / Env Fallback | Purpose |
-|--------|----------------------|---------|
+| -------- | ---------------------- | --------- |
 | `site` | `DOCS_SITE` or `https://f5-sales-demo.github.io` | Canonical base URL |
 | `base` | `DOCS_BASE` or `/` | URL base path for project sites |
 | `title` | `DOCS_TITLE` or `Documentation` | Site title in header and browser tab |
@@ -58,7 +58,7 @@ interface F5xcDocsConfigOptions {
 The factory wires up eight Starlight plugins automatically:
 
 | Plugin | Purpose |
-|--------|---------|
+| -------- | --------- |
 | `starlight-mega-menu` | Top navigation mega menu with grid/list layouts |
 | `starlight-videos` | Embed videos in documentation pages |
 | `starlight-image-zoom` | Click-to-zoom on images |

--- a/docs/en/build-pipeline.mdx
+++ b/docs/en/build-pipeline.mdx
@@ -9,7 +9,7 @@ This page describes how content repositories consume the `@f5-sales-demo/docs-th
 
 ## Architecture
 
-```
+```text
 ┌─────────────────┐
 │  Content Repo   │
 │  (docs/ folder) │
@@ -49,11 +49,13 @@ This page describes how content repositories consume the `@f5-sales-demo/docs-th
 
 1. **Content repo push** — a push to `main` (or manual dispatch) triggers the GitHub Pages Deploy workflow
 2. **Reusable workflow** — the content repo's workflow calls the builder:
+
    ```yaml
    jobs:
      docs:
        uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@main
    ```
+
 3. **Docker builder runs** — the `f5xc-docs-builder` Docker image already has the theme pre-installed via npm. At build time it:
    - Copies `astro.config.mjs` and `content.config.ts` from `node_modules/@f5-sales-demo/docs-theme/` into the Astro project root
    - Copies the content repo's `docs/` files into `src/content/docs/`

--- a/docs/en/colors.mdx
+++ b/docs/en/colors.mdx
@@ -51,7 +51,7 @@ The F5 palette uses seven primary brand colors plus black and white, each with f
 </div>
 
 | Name | HEX | RGB | CMYK | LESS | PMS | CSS Variable |
-|------|-----|-----|------|------|-----|--------------|
+| ------ | ----- | ----- | ------ | ------ | ----- | -------------- |
 | F5 Red | `#e4002b` | 228, 0, 43 | 0, 100, 81, 11 | `monza` | 185 | `--f5-red` |
 | Tangerine | `#f29a36` | 242, 154, 54 | 0, 36, 78, 5 | `carrot-orange` | 1375 | `--f5-tangerine` |
 | River | `#0e41aa` | 14, 65, 170 | 92, 62, 0, 33 | `tory-blue` | 293 | `--f5-river` |
@@ -96,7 +96,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#f7b2bf` | 247, 178, 191 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#f06680` | 240, 102, 128 | 0, 57, 47, 6 | `froly` |
 | 3 | `#a70020` | 167, 0, 32 | 0, 100, 81, 35 | `carmine` |
@@ -128,7 +128,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#ffe4c4` | 255, 228, 196 | 0, 11, 23, 0 | `tequila` |
 | 2 | `#ffbd61` | 255, 189, 97 | 0, 26, 62, 0 | `koromiko` |
 | 3 | `#a35700` | 163, 87, 0 | 0, 47, 100, 36 | `chelsea-gem` |
@@ -160,7 +160,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#b7c6e5` | 183, 198, 229 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#6e8dcc` | 110, 141, 204 | 0, 58, 47, 6 | `froly` |
 | 3 | `#0b3180` | 11, 49, 128 | 0, 100, 81, 35 | `carmine` |
@@ -192,7 +192,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#e6bed9` | 230, 190, 217 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#cd7db4` | 205, 125, 180 | 0, 58, 47, 6 | `froly` |
 | 3 | `#801d62` | 128, 29, 98 | 0, 100, 81, 35 | `carmine` |
@@ -224,7 +224,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#b2dfc4` | 178, 223, 196 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#66c088` | 102, 192, 136 | 0, 58, 47, 6 | `froly` |
 | 3 | `#00712b` | 0, 113, 43 | 0, 100, 81, 35 | `carmine` |
@@ -256,7 +256,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#cdabe3` | 205, 171, 227 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#9c59c9` | 156, 89, 201 | 0, 58, 47, 6 | `froly` |
 | 3 | `#822cb8` | 130, 44, 184 | 0, 100, 81, 35 | `carmine` |
@@ -288,7 +288,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#b2d7eb` | 178, 215, 235 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#66afd7` | 102, 175, 215 | 0, 58, 47, 6 | `froly` |
 | 3 | `#005c8d` | 0, 92, 141 | 0, 100, 81, 35 | `carmine` |
@@ -320,7 +320,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#faf9f7` | 250, 249, 247 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#f5f5f5` | 245, 245, 245 | 0, 58, 47, 6 | `froly` |
 | 3 | `#e6e6e6` | 230, 230, 230 | 0, 100, 81, 35 | `carmine` |
@@ -352,7 +352,7 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 </div>
 
 | Level | HEX | RGB | CMYK | LESS |
-|-------|-----|-----|------|------|
+| ------- | ----- | ----- | ------ | ------ |
 | 1 (lightest) | `#999999` | 153, 153, 153 | 0, 28, 23, 3 | `wewak` |
 | 2 | `#666666` | 102, 102, 102 | 0, 58, 47, 6 | `froly` |
 | 3 | `#343434` | 52, 52, 52 | 0, 100, 81, 35 | `carmine` |
@@ -362,7 +362,14 @@ The Brand Center assigns LESS variable names to secondary colors. Cloud Red and 
 
 Starlight exposes `--sl-color-*` variables for theming. Below is the mapping from the F5 palette to Starlight's semantic color slots, implemented in `styles/custom.css`.
 
-> **How Starlight theming works**: In Starlight, **dark mode is the bare `:root` default** — there is no `data-theme="dark"` selector. Light mode uses `:root[data-theme='light']`. The gray scale variables are *semantic*, not brightness-ordered: `gray-1` is always "primary text" and `gray-6`/`gray-7` are always "subtle backgrounds," regardless of mode. Their actual brightness values swap between modes. Similarly, `accent-high` is always the high-visibility accent text color and `accent-low` is always the subtle accent background — their brightness inverts between modes.
+> **How Starlight theming works**: In Starlight, **dark mode is the bare `:root`
+> default** — there is no `data-theme="dark"` selector. Light mode uses
+> `:root[data-theme='light']`. The gray scale variables are *semantic*, not
+> brightness-ordered: `gray-1` is always "primary text" and `gray-6`/`gray-7`
+> are always "subtle backgrounds," regardless of mode. Their actual brightness
+> values swap between modes. Similarly, `accent-high` is always the
+> high-visibility accent text color and `accent-low` is always the subtle accent
+> background — their brightness inverts between modes.
 
 ```css
 /* Dark mode — Starlight default (:root) */
@@ -487,11 +494,13 @@ Toggle the theme switcher to see these semantic tokens change between dark and l
 ### Contrast verification (WCAG AA)
 
 **Dark mode** (text on `#000000` page background):
+
 - Body text `#cccccc` → **16.3:1** (AAA)
 - Dim text `#999999` → **10:1** (AAA)
 - Accent link `#f06680` → **5.6:1** (AA)
 
 **Light mode** (text on `#ffffff` page background):
+
 - Body text `#343434` → **11.6:1** (AAA)
 - Dim text `#666666` → **5.7:1** (AA)
 - Accent link `#e4002b` → **4.6:1** (AA)
@@ -499,7 +508,7 @@ Toggle the theme switcher to see these semantic tokens change between dark and l
 ### Semantic color suggestions
 
 | Starlight Variable | F5 Color | Use Case |
-|--------------------|----------|----------|
+| -------------------- | ---------- | ---------- |
 | `--sl-color-accent` | F5 Red `#e4002b` | Links, buttons, active states |
 | `--sl-color-text-accent` | F5 Red Level 2 `#f06680` | Hover states in dark mode |
 | `--sl-color-bg-accent` | F5 Red Level 4 `#720016` | Accent backgrounds |
@@ -521,7 +530,7 @@ All color pairings must meet **WCAG AA** contrast requirements:
 ### Recommended safe pairings
 
 | Foreground | Background | Contrast Ratio | Passes |
-|------------|------------|----------------|--------|
+| ------------ | ------------ | ---------------- | -------- |
 | White `#ffffff` | F5 Red `#e4002b` | 4.6:1 | AA |
 | White `#ffffff` | River `#0e41aa` | 6.4:1 | AA / AAA |
 | White `#ffffff` | Bay `#0072b0` | 4.6:1 | AA |
@@ -537,7 +546,7 @@ All color pairings must meet **WCAG AA** contrast requirements:
 ## Usage Guidelines
 
 | Color Family | Role | When to Use |
-|--------------|------|-------------|
+| -------------- | ------ | ------------- |
 | **F5 Red** | Brand identity, primary CTAs | Hero sections, primary buttons, brand marks, error states |
 | **River** | Informational, trust | Navigation links, informational banners, data visualizations |
 | **Bay** | Informational, secondary | Secondary links, info callouts, code block accents |

--- a/docs/en/components.mdx
+++ b/docs/en/components.mdx
@@ -63,6 +63,7 @@ A list of items:
 - First item with **bold text**
 - Second item with `inline code`
 - Third item with a [link to Starlight docs](https://starlight.astro.build)
+
 :::
 
 ### Aside CSS
@@ -437,7 +438,7 @@ Check the sidebar: this page has a "New" badge with the `tip` variant applied vi
 ### Simple Table
 
 | Feature | Status | Priority |
-|---------|--------|----------|
+| --------- | -------- | ---------- |
 | Dark mode | Supported | High |
 | Image zoom | Supported | Medium |
 | Mermaid diagrams | Supported | Medium |
@@ -446,7 +447,7 @@ Check the sidebar: this page has a "New" badge with the `tip` variant applied vi
 ### Table with Alignment and Code
 
 | Property | Type | Default | Description |
-|:---------|:----:|--------:|:------------|
+| :--------- | :----: | --------: | :------------ |
 | `title` | `string` | — | Page title displayed in the header |
 | `description` | `string` | `""` | Meta description for SEO |
 | `sidebar.order` | `number` | `0` | Sort order in the sidebar |

--- a/docs/en/diagrams/instructions.mdx
+++ b/docs/en/diagrams/instructions.mdx
@@ -13,7 +13,7 @@ The theme includes a custom `remark-mermaid` plugin (`plugins/remark-mermaid.mjs
 
 Use the `@\{\}` node syntax to add icons from any registered icon pack:
 
-```
+```text
 nodeName@{ icon: 'pack:icon-name', label: 'Display Label' }
 ```
 
@@ -21,7 +21,7 @@ nodeName@{ icon: 'pack:icon-name', label: 'Display Label' }
 
 The `architecture-beta` diagram type supports service and group definitions with icon-decorated nodes:
 
-```
+```text
 service myService(pack:icon-name)[Label]
 group myGroup(pack:icon-name)[Label]
 ```
@@ -31,7 +31,7 @@ group myGroup(pack:icon-name)[Label]
 The following icon packs are registered and available in Mermaid diagrams. Icons are loaded lazily from CDN only when referenced.
 
 | Pack Name | npm Package | Key Icons |
-|-----------|-------------|-----------|
+| ----------- | ------------- | ----------- |
 | `hashicorp-flight` | `@f5-sales-demo/icons-hashicorp-flight` | `terraform-color`, `consul-color`, `vault-color`, `aws-color`, `azure-color`, `gcp-color`, `kubernetes-color`, `docker-color` |
 | `f5-brand` | `@f5-sales-demo/icons-f5-brand` | `network-gateway`, `security-firewall`, `security-shield-network`, `cloud-multi`, `hw-server` |
 | `f5xc` | `@f5-sales-demo/icons-f5xc` | `web-app-and-api-protection`, `bot-defense`, `multi-cloud-app-connect`, `dns-management`, `content-delivery-network` |

--- a/docs/en/environment-variables.mdx
+++ b/docs/en/environment-variables.mdx
@@ -10,7 +10,7 @@ The theme reads environment variables at build time from `config.ts` and custom 
 ## Variable Reference
 
 | Variable | Default | Purpose |
-|----------|---------|---------|
+| ---------- | --------- | --------- |
 | `DOCS_TITLE` | `Documentation` | Site title shown in the header and browser tab |
 | `DOCS_SITE` | `https://f5-sales-demo.github.io` | Canonical base URL for the deployed site |
 | `DOCS_BASE` | `/` | URL base path (e.g., `/my-repo/` for project sites) |

--- a/docs/en/footer.mdx
+++ b/docs/en/footer.mdx
@@ -42,7 +42,7 @@ Content repositories do not need to register the footer manually — it is appli
 ## Social Links
 
 | Platform | URL | Icon Color | Aria Label |
-|----------|-----|------------|------------|
+| ---------- | ----- | ------------ | ------------ |
 | Facebook | `https://www.facebook.com/f5incorporated` | `#1877F2` (Facebook Blue) | Facebook |
 | X | `https://x.com/F5` | `currentColor` (inherits) | X |
 | LinkedIn | `https://www.linkedin.com/company/f5/` | `#0A66C2` (LinkedIn Blue) | LinkedIn |
@@ -103,6 +103,7 @@ Modify the `fill` attribute on the `<svg>` element. Use `currentColor` to inheri
 ### Changing Layout
 
 Modify the `.social-links` CSS in the `<style>` block:
+
 - **Center alignment**: Change `justify-content` to `center`
 - **Wider spacing**: Increase the `gap` value
 - **Left alignment**: Change `justify-content` to `flex-start`

--- a/docs/en/logo.mdx
+++ b/docs/en/logo.mdx
@@ -12,7 +12,7 @@ The theme displays a logo in the site header of every documentation site.
 The theme ships two logo files in the `assets/` directory:
 
 | File | Format | Description |
-|------|--------|-------------|
+| --- | --- | --- |
 | `assets/f5-logo.svg` | SVG | F5 logo in Cloud Red (`#e4002b`) |
 | `assets/github-avatar.png` | PNG | GitHub organization avatar (default) |
 

--- a/docs/en/style-enhancement-guide.mdx
+++ b/docs/en/style-enhancement-guide.mdx
@@ -53,7 +53,7 @@ border: 1px solid var(--f5-border-default);  /* neutral at 20% alpha */
 #### Border Use Cases
 
 | Token | Opacity | Use Case |
-|---|---|---|
+| --- | --- | --- |
 | `--f5-border-faint` | 10% | Subtle separators, table rows |
 | `--f5-border-default` | 20% | Default borders, card outlines |
 | `--f5-border-strong` | 40% | Emphasized borders, active states |
@@ -67,7 +67,7 @@ Semantic surface tokens for hover and active states.
 #### Light Mode Surfaces
 
 | Token | Value | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `--f5-white` | `#ffffff` | Main backgrounds |
 | `--f5-white-1` | `#faf9f7` | Sidebar, subtle areas |
 | `--f5-white-2` | `#f5f5f5` | Elevated surfaces |
@@ -77,7 +77,7 @@ Semantic surface tokens for hover and active states.
 #### Dark Mode Surfaces
 
 | Token | Value | Purpose |
-|---|---|---|
+| --- | --- | --- |
 | `--f5-black` | `#000000` | Main backgrounds |
 | `--f5-black-4` | `#222222` | Sidebar, subtle areas |
 | `--f5-surface-hover` | `var(--f5-black-3)` | Hover fill |
@@ -150,7 +150,7 @@ The theme uses **neutral-tinted alpha shadows** with double-layer values for nat
 ### Component Shadow Mapping
 
 | Component | Shadow Level |
-|---|---|
+| --- | --- |
 | `.swatch`, `.icon-card` | `--f5-shadow-low` (at rest) |
 | `.starlight-aside` | `--f5-shadow-low` |
 | `.expressive-code .frame` | `--f5-shadow-mid` |
@@ -180,7 +180,7 @@ The theme uses **neutral-tinted alpha shadows** with double-layer values for nat
 ### Component Radius Mapping
 
 | Component | Radius Token |
-|---|---|
+| --- | --- |
 | `.swatch` | `--f5-radius-md` (6px) |
 | `.icon-card` | `--f5-radius-md` (6px) |
 | `.starlight-aside` | `--f5-radius-md` (6px) |
@@ -299,7 +299,7 @@ nav.sidebar a[aria-current="page"] {
 ### Button Size Scale
 
 | Size | Padding | Font Size | Min Height |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Small | `0.375rem 0.75rem` | `0.8125rem` (13px) | `32px` |
 | Medium (default) | `0.625rem 1rem` | `0.875rem` (14px) | `40px` |
 | Large | `0.75rem 1.5rem` | `1rem` (16px) | `48px` |
@@ -386,7 +386,7 @@ Using the F5 brand palette:
 ```
 
 | Token | Duration | Easing | Use Case |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | `--f5-transition-fast` | `0.15s` | `ease` | Most hover states, color changes |
 | `--f5-transition-base` | `0.2s` | `ease` | Background fills, border changes |
 | `--f5-transition-bounce` | `0.2s` | `cubic-bezier(0.68, -0.2, 0.265, 1.15)` | Switches, toggles |
@@ -396,7 +396,7 @@ Using the F5 brand palette:
 ### What to Animate
 
 | Property | Safe to Animate | Notes |
-|---|---|---|
+| --- | --- | --- |
 | `background-color` | Yes | Standard for hover fills |
 | `color` | Yes | Text color changes |
 | `border-color` | Yes | Border emphasis on hover |
@@ -499,7 +499,7 @@ textarea:focus-visible {
 ### Type Scale
 
 | Scale | Size | Line Height | Usage |
-|---|---|---|---|
+| --- | --- | --- | --- |
 | Display 500 | `1.875rem` (30px) | 1.267 | `--sl-text-h1` |
 | Display 400 | `1.5rem` (24px) | 1.333 | `--sl-text-h2` |
 | Display 300 | `1.125rem` (18px) | 1.333 | `--sl-text-h3` |
@@ -512,7 +512,7 @@ textarea:focus-visible {
 ### Key Characteristics
 
 | Aspect | Value | Notes |
-|---|---|---|
+| --- | --- | --- |
 | Heading line height | `1.1` | Tight headings for brand impact; consider `1.2` for readability |
 | Body line height | `1.5` (Starlight default) | Well-suited for reading |
 | Font family | Custom brand fonts | proximaNova (body), neusaNextProWide (headings) |
@@ -527,7 +527,7 @@ textarea:focus-visible {
 All design tokens were implemented across five sprints:
 
 | Sprint | Scope | Tokens Added |
-|---|---|---|
+| --- | --- | --- |
 | 1. Foundation | Shadows + border radius | `--f5-shadow-*` (5 levels), `--f5-radius-*` (5 levels) |
 | 2. Sidebar + Surfaces | Navigation + interactive tokens | `--f5-surface-hover`, `--f5-surface-active`, `--f5-border-*` (3 levels), `--f5-transition-fast` |
 | 3. Buttons | Component system | `.btn-primary`, `.btn-secondary`, `.btn-tertiary`, `.btn-critical`, size variants |

--- a/docs/en/typography.mdx
+++ b/docs/en/typography.mdx
@@ -25,7 +25,7 @@ Hierarchy is established through descending type size **and** contrast via alter
 The Brand Center specimen shows five styles:
 
 | Style | Weight Value | CSS `font-weight` | CSS `font-style` |
-|-------|-------------|-------------------|-------------------|
+| ------- | ------------- | ------------------- | ------------------- |
 | Light | 300 | `300` | `normal` |
 | Regular | 400 | `400` | `normal` |
 | Italic | 400 | `400` | `italic` |
@@ -39,7 +39,7 @@ The Brand Center specimen shows five styles:
 The Brand Center specimen shows four styles:
 
 | Style | Weight Value | CSS `font-weight` | CSS `font-style` |
-|-------|-------------|-------------------|-------------------|
+| ------- | ------------- | ------------------- | ------------------- |
 | Regular | 400 | `400` | `normal` |
 | Regular Italic | 400 | `400` | `italic` |
 | Bold | 700 | `700` | `normal` |
@@ -60,7 +60,7 @@ Proxima Nova is separately licensed and is **not** included in the Brand Center 
 ### Hierarchy Table
 
 | Element | Font | Weight | Case | Notes |
-|---------|------|--------|------|-------|
+| --------- | ------ | -------- | ------ | ------- |
 | Headline | Neusa Wide | Bold (700) | Sentence | Leading = 1.1× type size |
 | Eyebrow | Proxima Nova | Bold (700) | UPPERCASE | Small, with letter-spacing |
 | Subhead / Intro | Neusa Wide | Medium (500) | Sentence | Or Proxima Nova if immediately followed by body copy |
@@ -74,7 +74,7 @@ Proxima Nova is separately licensed and is **not** included in the Brand Center 
 ### Specialized Treatments
 
 | Context | Font | Weight | Size/Leading | Notes |
-|---------|------|--------|-------------|-------|
+| --------- | ------ | -------- | ------------- | ------- |
 | Collateral pull quotes | Neusa Wide | Bold (700) | 9pt / 14pt | Sentence case |
 | eBook pull quotes | Neusa Wide | Regular (400) | 16pt / 19pt | With rule above |
 | Infographic numerals/factoids | Neusa Wide | Light (300) | — | For visual impact at large sizes |
@@ -83,6 +83,7 @@ Proxima Nova is separately licensed and is **not** included in the Brand Center 
 ### Title Case Usage
 
 Title case may be used for:
+
 - Subheads
 - Pull quotes
 - Numeric stats
@@ -130,7 +131,7 @@ This is a combination: **bold with `inline code` inside** and *italic with `code
 - First bullet point
 - Second bullet with **emphasis**
 - Third bullet with `code reference`
-- Fourth bullet with a [link](https://starlight.astro.build)
+- Fourth bullet with a [link to the Starlight documentation](https://starlight.astro.build)
 
 ### Nested Lists
 
@@ -145,11 +146,17 @@ This is a combination: **bold with `inline code` inside** and *italic with `code
 
 ### Blockquotes
 
+Single-line blockquote:
+
 > This is a single-line blockquote.
+
+Multi-line blockquote:
 
 > This is a multi-line blockquote.
 >
 > It spans multiple paragraphs and can contain **bold**, *italic*, and `code` formatting.
+
+Nested blockquote:
 
 > Nested blockquotes:
 >
@@ -188,7 +195,7 @@ The theme ships **10 woff2 files** in the `fonts/` directory:
 ### Neusa Next Pro Wide
 
 | File | Weight | Style | Size |
-|------|--------|-------|------|
+| ------ | -------- | ------- | ------ |
 | `neusaNextProWide-300.woff2` | 300 (Light) | Normal | ~49 KB |
 | `neusaNextProWide-400.woff2` | 400 (Regular) | Normal | ~49 KB |
 | `neusaNextProWide-400i.woff2` | 400 (Regular) | Italic | ~49 KB |
@@ -196,10 +203,10 @@ The theme ships **10 woff2 files** in the `fonts/` directory:
 | `neusaNextProWide-700.woff2` | 700 (Bold) | Normal | ~49 KB |
 | `neusaNextProWide-700i.woff2` | 700 (Bold) | Italic | ~49 KB |
 
-### Proxima Nova
+### Proxima Nova font files
 
 | File | Weight | Style | Size |
-|------|--------|-------|------|
+| ------ | -------- | ------- | ------ |
 | `proximaNova-400.woff2` | 400 (Regular) | Normal | ~18 KB |
 | `proximaNova-500.woff2` | 500 (Medium) | Normal | ~18 KB |
 | `proximaNova-600.woff2` | 600 (Semi-Bold) | Normal | ~18 KB |
@@ -214,7 +221,7 @@ Font files follow the pattern `familyName-weight.woff2`, with an `i` suffix for 
 The following italic variants are not yet available in the theme:
 
 | Missing Variant | Reason |
-|----------------|--------|
+| ---------------- | -------- |
 | Proxima Nova 400 italic | Source file not available in current downloads |
 | Proxima Nova 500 italic | Source file not available in current downloads |
 | Proxima Nova 600 italic (Semi-Bold) | Source file not available |
@@ -246,7 +253,7 @@ To add a new font variant, append a `@font-face` block to `font-face.css`:
 
 The theme plugin (`index.ts`) injects both CSS files via the `config:setup` hook:
 
-```
+```text
 index.ts → fonts/font-face.css → styles/custom.css → Starlight renders
 ```
 
@@ -274,7 +281,7 @@ h1, h2, h3, h4, h5, h6 {
 The theme overrides these Starlight CSS custom properties:
 
 | Token | Value | Purpose |
-|-------|-------|---------|
+| ------- | ------- | --------- |
 | `--sl-font` | `"proximaNova", ...` | Body text, UI elements |
 | `--sl-font-heading` | `"neusaNextProWide", ...` | Custom token for heading font |
 | `--sl-line-height-headings` | `1.1` | Cloud brand headline leading |
@@ -286,7 +293,7 @@ The theme overrides these Starlight CSS custom properties:
 ### Heading Hierarchy Mapping
 
 | HTML | Font Family | Weight | Case | Brand Role |
-|------|------------|--------|------|------------|
+| ------ | ------------ | -------- | ------ | ------------ |
 | `h1` | Neusa Next Wide | 700 (Bold) | Sentence | Headline |
 | `h2` | Neusa Next Wide | 700 (Bold) | Sentence | Subhead |
 | `h3` | Neusa Next Wide | 500 (Medium) | Sentence | Intro / Sub-subhead |
@@ -299,7 +306,7 @@ The theme overrides these Starlight CSS custom properties:
 To use different font families:
 
 1. **Add woff2 files** to `fonts/` using the naming convention `familyName-weight.woff2` (add `i` suffix for italic)
-2. **Update `fonts/font-face.css`** with new `@font-face` rules matching your file names, weights, and styles
+2. **Update `fonts/font-face.css`** with new `@font-face` rules matching your filenames, weights, and styles
 3. **Update `styles/custom.css`** to set `--sl-font` and heading `font-family` to your new family names
 4. **Keep the fallback stack** (`system-ui, "Segoe UI", Helvetica, Arial, sans-serif`) for fast initial rendering
 


### PR DESCRIPTION
## Summary

- normalize English documentation tables and list spacing for enforced Markdown rules
- tag the remaining English code fences and disambiguate a repeated heading
- keep translated sources untouched for the planned final locale regeneration

Closes #1088

## Testing

- markdownlint-cli 0.49.1 on every changed Markdown/MDX file
- `bash scripts/lint-mdx-prose.sh --changed origin/main` (10 MDX files)
- shellcheck and shfmt over every tracked shell script
- `npm test` (45 passed)
- `npm run build` (391 pages)
- `git diff --check origin/main...HEAD`