### PR TITLE
feat: add xcsh action to shared navigation

### DIFF
--- a/config.test.ts
+++ b/config.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from 'vitest';
+import { defaultMegaMenuItems, federatedSearchSites } from './config';
+import { f5xcDefaultLocales } from './src/i18n/locales';
+
+describe('default ecosystem navigation', () => {
+  it('consolidates developer automation under Platform', () => {
+    expect(defaultMegaMenuItems.map((item) => item.label)).not.toContain('Tools');
+
+    const platform = defaultMegaMenuItems.find((item) => item.label === 'Platform');
+    const developerAutomation = platform?.content?.categories?.find(
+      (category) => category.title === 'Developer Automation',
+    );
+
+    expect(developerAutomation?.items.map((item) => item.label)).toEqual([
+      'Terraform Provider',
+      'API Specs',
+      'API Specs Enriched',
+      'xcsh Manifest Automation',
+      'VS Code Extension',
+      'xcsh CLI',
+      'xcsh Chrome Extension',
+    ]);
+    expect(Object.keys(developerAutomation?.translations ?? {})).toHaveLength(
+      Object.keys(f5xcDefaultLocales).length - 1,
+    );
+  });
+
+  it('keeps the product name stable and localizes its description', () => {
+    const platform = defaultMegaMenuItems.find((item) => item.label === 'Platform');
+    const action = platform?.content?.categories
+      ?.flatMap((category) => category.items)
+      .find((item) => item.label === 'xcsh Manifest Automation');
+
+    expect(action?.href).toBe('https://f5-sales-demo.github.io/xcsh-action/');
+    expect(action).not.toHaveProperty('translations');
+    expect(Object.keys(action?.descriptionTranslations ?? {})).toHaveLength(Object.keys(f5xcDefaultLocales).length - 1);
+  });
+
+  it('retains xcsh under AI and registers the Action for federated search', () => {
+    const ai = defaultMegaMenuItems.find((item) => item.label === 'AI');
+    expect(ai?.content?.categories?.flatMap((category) => category.items).map((item) => item.label)).toContain('xcsh');
+    expect(federatedSearchSites).toContainEqual({ repo: 'xcsh-action', label: 'xcsh Manifest Automation' });
+  });
+});

--- a/config.ts
+++ b/config.ts
@@ -88,7 +88,18 @@ export interface F5xcDocsConfigOptions {
   defaultLocale?: string;
 }
 
-const defaultMegaMenuItems: MegaMenuItem[] = [
+const developerAutomationTranslations = Object.fromEntries(
+  Object.entries(categoryTitles.Automation).map(([locale, automation]) => [
+    locale,
+    `${categoryTitles['Developer Tools'][locale]} / ${automation}`,
+  ]),
+);
+
+const xcshActionDescriptionTranslations = Object.fromEntries(
+  Object.entries(categoryTitles.Automation).map(([locale, automation]) => [locale, `F5 XC — ${automation}`]),
+);
+
+export const defaultMegaMenuItems: MegaMenuItem[] = [
   {
     label: 'Security',
     translations: menuLabels.Security,
@@ -308,8 +319,8 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
           ],
         },
         {
-          title: 'Automation',
-          translations: categoryTitles.Automation,
+          title: 'Developer Automation',
+          translations: developerAutomationTranslations,
           items: [
             {
               label: 'Terraform Provider',
@@ -334,6 +345,37 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
               descriptionTranslations: itemDescriptions['Enriched OpenAPI specifications'],
               href: 'https://f5-sales-demo.github.io/api-specs-enriched/',
               icon: resolveIcon('f5xc:data-intelligence'),
+            },
+            {
+              label: 'xcsh Manifest Automation',
+              description: 'Deterministic F5 XC manifest operations in GitHub Actions',
+              descriptionTranslations: xcshActionDescriptionTranslations,
+              href: 'https://f5-sales-demo.github.io/xcsh-action/',
+              icon: resolveIcon('carbon:workflow-automation'),
+            },
+            {
+              label: 'VS Code Extension',
+              translations: itemLabels['VS Code Extension'],
+              description: 'Manage F5 XC resources from VS Code',
+              descriptionTranslations: itemDescriptions['Manage F5 XC resources from VS Code'],
+              href: 'https://f5-sales-demo.github.io/vscode-xcsh/',
+              icon: resolveIcon('carbon:code'),
+            },
+            {
+              label: 'xcsh CLI',
+              translations: itemLabels['xcsh CLI'],
+              description: 'AI-powered CLI for F5 XC',
+              descriptionTranslations: itemDescriptions['AI-powered CLI for F5 XC'],
+              href: 'https://f5-sales-demo.github.io/xcsh/',
+              icon: resolveIcon('carbon:terminal'),
+            },
+            {
+              label: 'xcsh Chrome Extension',
+              translations: itemLabels['xcsh Chrome Extension'],
+              description: 'Drive the F5 XC console with xcsh',
+              descriptionTranslations: itemDescriptions['Drive the F5 XC console with xcsh'],
+              href: 'https://f5-sales-demo.github.io/xcsh-chrome-extension/',
+              icon: resolveIcon('carbon:application-web'),
             },
           ],
         },
@@ -472,45 +514,6 @@ const defaultMegaMenuItems: MegaMenuItem[] = [
       ],
     },
   },
-  {
-    label: 'Tools',
-    translations: menuLabels.Tools,
-    content: {
-      layout: 'list',
-      categories: [
-        {
-          title: 'Developer Tools',
-          translations: categoryTitles['Developer Tools'],
-          items: [
-            {
-              label: 'VS Code Extension',
-              translations: itemLabels['VS Code Extension'],
-              description: 'Manage F5 XC resources from VS Code',
-              descriptionTranslations: itemDescriptions['Manage F5 XC resources from VS Code'],
-              href: 'https://f5-sales-demo.github.io/vscode-xcsh/',
-              icon: resolveIcon('carbon:code'),
-            },
-            {
-              label: 'xcsh CLI',
-              translations: itemLabels['xcsh CLI'],
-              description: 'AI-powered CLI for F5 XC',
-              descriptionTranslations: itemDescriptions['AI-powered CLI for F5 XC'],
-              href: 'https://f5-sales-demo.github.io/xcsh/',
-              icon: resolveIcon('carbon:terminal'),
-            },
-            {
-              label: 'xcsh Chrome Extension',
-              translations: itemLabels['xcsh Chrome Extension'],
-              description: 'Drive the F5 XC console with xcsh',
-              descriptionTranslations: itemDescriptions['Drive the F5 XC console with xcsh'],
-              href: 'https://f5-sales-demo.github.io/xcsh-chrome-extension/',
-              icon: resolveIcon('carbon:application-web'),
-            },
-          ],
-        },
-      ],
-    },
-  },
 ];
 
 const defaultHead: HeadEntry[] = [
@@ -556,7 +559,7 @@ mermaid.initialize({
   },
 ];
 
-const federatedSearchSites = [
+export const federatedSearchSites = [
   { repo: 'docs-builder', label: 'Docs Builder' },
   { repo: 'docs-theme', label: 'Docs Theme' },
   { repo: 'docs', label: 'F5 XC Docs' },
@@ -573,6 +576,7 @@ const federatedSearchSites = [
   { repo: 'waf', label: 'WAF' },
   { repo: 'api-protection', label: 'API Security' },
   { repo: 'xcsh', label: 'xcsh' },
+  { repo: 'xcsh-action', label: 'xcsh Manifest Automation' },
   { repo: 'csd', label: 'Client-Side Defense' },
   { repo: 'docs-icons', label: 'Docs Icons' },
   { repo: 'devcontainer', label: 'Dev Container' },


### PR DESCRIPTION
## Summary

Integrates xcsh Manifest Automation into the shared ecosystem navigation and federated search. The top-level Tools menu is consolidated into Platform / Developer Automation, while xcsh remains available under AI.

## Related Issue

Closes #1149

## Changes

- compose Developer Automation labels from the existing governed locale strings
- add xcsh Manifest Automation and the existing xcsh developer tools under Platform
- remove the redundant top-level Tools menu
- register xcsh-action in federated search
- add unit coverage for structure, locale completeness, stable naming, URL, and search registration

## Verification evidence

- `pre-commit run --files config.ts config.test.ts` — passed
- `bash scripts/check-pii.sh --scope staged --mode enforce` — clean
- `bash scripts/check-pii.sh --scope head --mode enforce` — clean
- `npm test` — 6 files and 50 tests passed
- `npm run build` — 391 pages built; Pagefind indexed 392 HTML files
- rendered locale roots — xcsh entry and target present in all 13 locales
- `bash scripts/agy-pre-push-review.sh` — passed with no high or critical findings

The repository-wide hook run also reports pre-existing findings outside this diff: terminology in `docs/en/code-blocks.mdx` and an unpinned action in the governed `dispatch-downstream.yml` workflow. Changed-file hooks pass.

## Checklist

- [x] Linked to a GitHub issue (required — CI blocks merge without it)
- [x] Feature-complete and verified — not exploratory or trial-and-error code
- [x] Tests are present and passing; the issue acceptance criteria are met
- [x] Verified locally by exercising tests, production build, and rendered locale output
- [ ] CI watched to green (not just queued)
- [x] Follows project conventions
