### PR TITLE
fix: restore secure release workflows

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -15,6 +15,7 @@ jobs:
   dispatch:
     name: Notify f5xc-docs-builder
     runs-on: ubuntu-latest
+    environment: release
     steps:
       - name: Verify npm package version exists
         env:
@@ -37,7 +38,7 @@ jobs:
           exit 1
 
       - name: Dispatch rebuild-image event
-        uses: peter-evans/repository-dispatch@v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           repository: f5-sales-demo/docs-builder

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,10 +15,6 @@ on:
       - 'LICENSE'
   workflow_dispatch:
 
-permissions:
-  contents: write
-  id-token: write
-
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -26,7 +22,11 @@ concurrency:
 jobs:
   release:
     name: Semantic Release
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
+    environment: release
+    permissions:
+      contents: read # Checkout needs only repository read access.
+      id-token: write # npm provenance exchanges this OIDC token for a signing identity.
     if: "!contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.head_commit.message, 'chore(release):')"
     steps:
       - name: Checkout


### PR DESCRIPTION
## Summary

- route npm provenance publishing to GitHub-hosted Ubuntu
- scope Release permissions and bind secret-bearing jobs to the restricted `release` environment
- pin downstream repository dispatch to an immutable action commit

## Validation

- Zizmor 1.29 auditor: zero findings across all workflows
- Vitest: 50 passed
- Astro production build: 391 pages built
- npm package dry run: passed

Closes #687
