### PR TITLE
fix: deny default release permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,6 +15,8 @@ on:
       - 'LICENSE'
   workflow_dispatch:
 
+permissions: {}
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
@@ -71,6 +73,7 @@ jobs:
         run: |
           package_name=$(node -p "require('./package.json').name")
           package_version=$RELEASE_VERSION
+          # shellcheck disable=SC2153 # Assigned by the step environment below.
           expected_integrity=$EXPECTED_INTEGRITY
 
           registry_integrity() {


### PR DESCRIPTION
## Summary

- explicitly deny default workflow permissions before applying the Release job's minimal grants
- document the step-environment assignment for ShellCheck

## Validation

- Zizmor 1.29 online auditor: zero findings across every workflow
- Actionlint: passed

Closes #687
