### PR TITLE
ci: migrate custom workflows to self-hosted runners

### DIFF
--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   dispatch:
     name: Notify f5xc-docs-builder
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64, docs-theme]
     environment: release
     steps:
       - name: Verify npm package version exists
@@ -38,7 +38,7 @@ jobs:
           exit 1
 
       - name: Dispatch rebuild-image event
-        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           token: ${{ secrets.RELEASE_TOKEN }}
           repository: f5-sales-demo/docs-builder

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   dispatch:
     name: Notify f5xc-docs-builder
-    runs-on: [self-hosted, Linux, X64, docs-theme]
+    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
     environment: release
     steps:
       - name: Verify npm package version exists

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   release:
     name: Semantic Release
-    runs-on: ubuntu-24.04
+    runs-on: [self-hosted, Linux, X64, docs-theme]
     environment: release
     permissions:
       contents: read # Checkout needs only repository read access.

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   release:
     name: Semantic Release
-    runs-on: [self-hosted, Linux, X64, docs-theme]
+    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
     environment: release
     permissions:
       contents: read # Checkout needs only repository read access.

--- a/actionlint.yml
+++ b/actionlint.yml
@@ -1,7 +1,46 @@
 ---
 self-hosted-runner:
   labels:
+    - administration
+    - api-protection
+    - api-specs
+    - api-specs-enriched
+    - apt-repo
+    - bot-advanced
+    - bot-standard
+    - cdn
+    - cdn-simulator
+    - console
+    - container-build
+    - csd
+    - ddos
+    - demo-resource-template
+    - demo-resources
+    - devcontainer
+    - dns
+    - docs
+    - docs-builder
+    - docs-control
+    - docs-icons
+    - docs-theme
+    - i18n-core
+    - marketplace
+    - marketplace-claude-code
+    - mcn
+    - nginx
+    - observability
+    - origin-server
+    - starlight-llms-txt
+    - starlight-mega-menu
     - terraform-provider-xcsh
+    - traffic-generator
     - ubuntu-24.04-arm
+    - vscode-xcsh
+    - waf
+    - was
+    - webapp-api-protection
+    - xcsh
+    - xcsh-action
+    - xcsh-chrome-extension
 
 config-variables: null


### PR DESCRIPTION
Closes #1204

- route Linux jobs to repository-scoped self-hosted runners
- preserve explicit native macOS, Windows, and ARM64 coverage where applicable
- pin Marketplace actions to current stable release SHAs

Validation: central runner-routing and immutable-pin audit; actionlint syntax validation; git diff checks.