### PR TITLE
fix(theme): improve mobile site title truncation and responsive splash hero layout

### DIFF
--- a/components/SiteTitle.astro
+++ b/components/SiteTitle.astro
@@ -45,6 +45,9 @@ const { siteTitle } = Astro.locals.starlightRoute;
   }
   span {
     overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
   }
   img {
     height: calc(var(--sl-nav-height) - 2 * var(--sl-nav-pad-y));
@@ -52,5 +55,6 @@ const { siteTitle } = Astro.locals.starlightRoute;
     max-width: 100%;
     object-fit: contain;
     object-position: 0 50%;
+    flex-shrink: 0;
   }
 </style>

--- a/styles/custom.css
+++ b/styles/custom.css
@@ -805,3 +805,68 @@ summary:focus-visible {
   height: 2.5rem;
   margin-top: 0;
 }
+
+/* ===== Responsive Splash Hero Layout & Mobile Header ===== */
+.site-title {
+  min-width: 0;
+}
+
+.site-title span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  min-width: 0;
+}
+
+@media (max-width: 49.99rem) {
+  .hero {
+    display: flex;
+    flex-direction: column;
+    gap: 1.25rem;
+    padding-block: 1rem 1.5rem;
+  }
+
+  .hero > .stack {
+    order: 1;
+    width: 100%;
+    gap: 1.25rem;
+  }
+
+  .hero > img,
+  .hero > picture,
+  .hero > .hero-html {
+    order: 2;
+    width: min(75%, 15rem);
+    max-height: 12rem;
+    margin-inline: auto;
+    object-fit: contain;
+  }
+
+  .hero > .hero-html img {
+    max-height: 12rem;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+}
+
+@media (min-width: 50rem) {
+  .hero {
+    padding-block: clamp(1.5rem, calc(1rem + 3vmin), 3rem);
+    gap: clamp(1.5rem, 3vw, 3rem);
+  }
+
+  .hero > img,
+  .hero > picture,
+  .hero > .hero-html {
+    max-height: 20rem;
+  }
+
+  .hero > .hero-html img {
+    max-height: 20rem;
+    width: auto;
+    max-width: 100%;
+    object-fit: contain;
+  }
+}
+

--- a/tests/visual/responsive-hero-header.spec.ts
+++ b/tests/visual/responsive-hero-header.spec.ts
@@ -95,7 +95,7 @@ test.describe('Responsive Header and Splash Hero', () => {
 
       // First content heading below hero is visible at or near bottom of 1440x900 viewport
       const firstHeading = page.locator('.main-pane h2, .sl-markdown-content h2, main h2').first();
-      if (await firstHeading.count() > 0) {
+      if ((await firstHeading.count()) > 0) {
         const headingBox = await firstHeading.boundingBox();
         if (headingBox) {
           expect(headingBox.y).toBeLessThan(900);

--- a/tests/visual/responsive-hero-header.spec.ts
+++ b/tests/visual/responsive-hero-header.spec.ts
@@ -1,0 +1,106 @@
+import { expect, test } from '@playwright/test';
+
+const themes = ['dark', 'light'] as const;
+
+function setTheme(theme: 'dark' | 'light') {
+  return `
+    document.documentElement.setAttribute('data-theme', '${theme}');
+    localStorage.setItem('starlight-theme', '${theme}');
+  `;
+}
+
+test.describe('Responsive Header and Splash Hero', () => {
+  for (const theme of themes) {
+    test(`Mobile 390x844 (${theme} mode): Site title truncation and hero order`, async ({ page }) => {
+      await page.setViewportSize({ width: 390, height: 844 });
+      await page.addInitScript(setTheme(theme));
+      const response = await page.goto('./', { waitUntil: 'networkidle' });
+      expect(response?.status()).toBe(200);
+      await page.evaluate(setTheme(theme));
+      await page.evaluate(() => document.fonts.ready);
+
+      // 1. No horizontal overflow on the page
+      const hasHorizontalScrollbar = await page.evaluate(() => {
+        return document.documentElement.scrollWidth > document.documentElement.clientWidth;
+      });
+      expect(hasHorizontalScrollbar).toBe(false);
+
+      // 2. Site title has text-overflow: ellipsis and does not overlap other controls
+      const siteTitleSpan = page.locator('.site-title span').first();
+      await expect(siteTitleSpan).toBeVisible();
+      const textOverflow = await siteTitleSpan.evaluate((el) => window.getComputedStyle(el).textOverflow);
+      expect(textOverflow).toBe('ellipsis');
+
+      // 3. Full text is preserved in markup
+      const titleText = await siteTitleSpan.textContent();
+      expect(titleText?.trim().length).toBeGreaterThan(0);
+
+      // 4. Hero reading order: H1 -> Tagline/Actions -> Illustration
+      const hero = page.locator('.hero');
+      await expect(hero).toBeVisible();
+
+      const h1 = hero.locator('h1').first();
+      const actions = hero.locator('.actions').first();
+      const heroImage = hero.locator('> img, > picture, > .hero-html').first();
+
+      const h1Box = await h1.boundingBox();
+      const imageBox = await heroImage.boundingBox();
+
+      expect(h1Box).not.toBeNull();
+      expect(imageBox).not.toBeNull();
+
+      if (h1Box && imageBox) {
+        // H1 must appear above the hero illustration on mobile
+        expect(h1Box.y).toBeLessThan(imageBox.y);
+      }
+
+      if (await actions.isVisible()) {
+        const actionsBox = await actions.boundingBox();
+        if (actionsBox && imageBox) {
+          // Actions must appear above the hero illustration on mobile
+          expect(actionsBox.y).toBeLessThan(imageBox.y);
+        }
+      }
+
+      // 5. Hero illustration height constraint
+      if (imageBox) {
+        expect(imageBox.height).toBeLessThanOrEqual(220);
+      }
+    });
+
+    test(`Desktop 1440x900 (${theme} mode): Splash hero vertical density`, async ({ page }) => {
+      await page.setViewportSize({ width: 1440, height: 900 });
+      await page.addInitScript(setTheme(theme));
+      const response = await page.goto('./', { waitUntil: 'networkidle' });
+      expect(response?.status()).toBe(200);
+      await page.evaluate(setTheme(theme));
+      await page.evaluate(() => document.fonts.ready);
+
+      const hero = page.locator('.hero');
+      await expect(hero).toBeVisible();
+
+      const h1 = hero.locator('h1').first();
+      const heroImage = hero.locator('> img, > picture, > .hero-html').first();
+
+      const h1Box = await h1.boundingBox();
+      const imageBox = await heroImage.boundingBox();
+
+      expect(h1Box).not.toBeNull();
+      expect(imageBox).not.toBeNull();
+
+      // On desktop, two-column layout: copy is on left, image is on right
+      if (h1Box && imageBox) {
+        expect(h1Box.x).toBeLessThan(imageBox.x);
+      }
+
+      // First content heading below hero is visible at or near bottom of 1440x900 viewport
+      const firstHeading = page.locator('.main-pane h2, .sl-markdown-content h2, main h2').first();
+      if (await firstHeading.count() > 0) {
+        const headingBox = await firstHeading.boundingBox();
+        if (headingBox) {
+          expect(headingBox.y).toBeLessThan(900);
+        }
+      }
+    });
+  }
+});


### PR DESCRIPTION
Closes #1255

### Summary of changes
- **Mobile site title truncation**: Enabled ellipsis truncation, `min-width: 0`, and `white-space: nowrap` on the site title text span and flex layout to eliminate character clipping mid-glyph. Set `flex-shrink: 0` on the logo image.
- **Mobile splash hero layout**: Adjusted small-screen hero ordering so the copy stack (H1, tagline, actions) precedes the illustration, and constrained mobile illustration sizing (`width: min(75%, 15rem)`, `max-height: 12rem`) to bring the first content section into view promptly without DOM shift.
- **Desktop splash hero density**: Reduced excessive hero vertical padding (`clamp(1.5rem, calc(1rem + 3vmin), 3rem)`) while preserving two-column composition, ensuring the initial content section below the hero is visible on 1440x900 viewports.
- **Visual & behavioral tests**: Added Playwright test suite (`tests/visual/responsive-hero-header.spec.ts`) covering 390x844 mobile and 1440x900 desktop in light and dark modes.