### PR TITLE
fix(ci): omit npm provenance flag on self-hosted release runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
           delay=10
           while [ $attempt -le $max_attempts ]; do
             echo "Attempt $attempt of $max_attempts"
-            if npm publish "$PACKAGE_PATH" --access public --provenance; then
+            if npm publish "$PACKAGE_PATH" --access public; then
               exit 0
             fi
             if published_integrity=$(registry_integrity); then


### PR DESCRIPTION
Closes #1257

### Changes
- Remove `--provenance` from `npm publish` in `.github/workflows/release.yml` to enable package publishing on self-hosted runners without Sigstore provenance errors.