### PR TITLE
chore: sync managed files from governance template

### DIFF
--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Set up pinned Python and uv
         uses: astral-sh/setup-uv@ae62891fec2bb8e7d6c99fc78c9fec3a63790f8d # v10.0.0
         with:
-          version: '0.8.13'
+          version: '0.8.24'
           python-version: '3.13.7'
 
       - name: Reject every workflow security finding


### PR DESCRIPTION
Closes #1272

Synced managed files from `f5-sales-demo/docs-control` canonical source:

- .github/workflows/workflow-security-audit.yml