### PR TITLE
ci: add immutable runner Node smoke

### DIFF
--- a/.github/workflows/self-hosted-runner-node-smoke.yml
+++ b/.github/workflows/self-hosted-runner-node-smoke.yml
@@ -1,0 +1,51 @@
+---
+name: Self-hosted Runner Node Smoke
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: self-hosted-runner-node-smoke-${{ github.repository }}
+  cancel-in-progress: false
+
+jobs:
+  tool-cache-smoke:
+    name: Validate catalogued Node
+    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
+    timeout-minutes: 10
+    steps:
+      - name: Assert private cache and immutable image boundaries
+        shell: bash
+        run: |
+          set -euo pipefail
+          : "${RUNNER_RUNTIME_DIR:?RUNNER_RUNTIME_DIR must be set}"
+          : "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}"
+          runtime_dir="$(realpath -m -- "$RUNNER_RUNTIME_DIR")"
+          tool_cache="$(realpath -m -- "$RUNNER_TOOL_CACHE")"
+          test "$tool_cache" = "$runtime_dir/_tool"
+          test -f "$tool_cache/node/24.14.1/x64.complete"
+          test -f /opt/hostedtoolcache/node/24.14.1/x64.complete
+          if touch /.self-hosted-runner-node-smoke; then
+            rm -f /.self-hosted-runner-node-smoke
+            echo "the runner root filesystem must be read-only" >&2
+            exit 1
+          fi
+          if touch /opt/hostedtoolcache/.self-hosted-runner-node-smoke; then
+            rm -f /opt/hostedtoolcache/.self-hosted-runner-node-smoke
+            echo "the image tool cache must be read-only" >&2
+            exit 1
+          fi
+
+      - name: Resolve catalogued Node from the private tool cache
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: 24.14.1
+
+      - name: Verify Node version
+        shell: bash
+        run: |
+          set -euo pipefail
+          test "$(node --version)" = "v24.14.1"


### PR DESCRIPTION
## Summary

- add a manual standard-profile smoke for the catalogued Node 24.14.1 tool cache
- assert the private writable cache and immutable image-root boundaries

## Validation

- actionlint and yamllint
- workflow-security-validator and runner workflow audit

Closes #1276
