### PR TITLE
Remove governed README verification marker

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,5 +33,3 @@ branch naming, and CI requirements.
 ## License
 
 See [LICENSE](LICENSE).
-
-<!-- linked-issue verification: #1289 -->


### PR DESCRIPTION
Removes only the governed README verification marker from PR #1290.

Closes #1291
