### PR TITLE
ci(runners): migrate docs-theme workflows to repository-scoped ARC

### DIFF
--- a/.github/workflows/auto-merge.yml
+++ b/.github/workflows/auto-merge.yml
@@ -31,7 +31,7 @@ jobs:
       github.event.pull_request.draft == false &&
       github.actor != 'dependabot[bot]' &&
       github.event.pull_request.head.repo.full_name == github.repository
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Require downstream-triggering token
         env:

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   auto-merge:
     name: Approve and enable auto-merge
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     permissions:
       contents: write # merge validated Dependabot updates
       pull-requests: write # approve pull requests and enable auto-merge

--- a/.github/workflows/dispatch-downstream.yml
+++ b/.github/workflows/dispatch-downstream.yml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   dispatch:
     name: Notify f5xc-docs-builder
-    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
+    runs-on: docs-socketless
     environment: release
     steps:
       - name: Verify npm package version exists

--- a/.github/workflows/github-pages-deploy.yml
+++ b/.github/workflows/github-pages-deploy.yml
@@ -20,6 +20,8 @@ jobs:
   docs:
     uses: f5-sales-demo/docs-control/.github/workflows/github-pages-deploy.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
+      socketless_runner_label: docs-socketless
+      container_build_runner_label: docs-container-build
       content-ref: ${{ github.sha }}
     permissions:
       contents: read # read documentation sources

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   release:
     name: Semantic Release
-    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
+    runs-on: docs-socketless
     environment: release
     permissions:
       contents: read # Checkout needs only repository read access.

--- a/.github/workflows/require-linked-issue.yml
+++ b/.github/workflows/require-linked-issue.yml
@@ -19,7 +19,7 @@ jobs:
       github.event.pull_request.head.repo.full_name == github.repository &&
       !startsWith(github.event.pull_request.head.ref, 'governance/reconcile-')
     name: Check linked issues
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     permissions:
       pull-requests: read # inspect linked issues on the current pull request
     steps:

--- a/.github/workflows/self-hosted-runner-node-smoke.yml
+++ b/.github/workflows/self-hosted-runner-node-smoke.yml
@@ -15,7 +15,7 @@ concurrency:
 jobs:
   tool-cache-smoke:
     name: Validate catalogued Node
-    runs-on: [self-hosted, Linux, X64, docs-theme, ubuntu-24.04]
+    runs-on: docs-socketless
     timeout-minutes: 10
     steps:
       - name: Assert private cache and immutable image boundaries

--- a/.github/workflows/self-hosted-runner-node-smoke.yml
+++ b/.github/workflows/self-hosted-runner-node-smoke.yml
@@ -5,7 +5,7 @@ on:
   workflow_dispatch:
 
 # The smoke has no repository/API interaction: it proves only the immutable
-# runner image and its private, per-job tool cache.
+# runner image catalog exposed to the ephemeral ARC job.
 permissions: {}
 
 concurrency:
@@ -22,19 +22,16 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          runtime_dir="$(realpath -m -- "${RUNNER_RUNTIME_DIR:?RUNNER_RUNTIME_DIR must be set}")"
+          catalog_dir="$(realpath -m -- "${AGENT_TOOLSDIRECTORY:?AGENT_TOOLSDIRECTORY must be set}")"
           tool_cache="$(realpath -m -- "${RUNNER_TOOL_CACHE:?RUNNER_TOOL_CACHE must be set}")"
-          test "$tool_cache" = "$runtime_dir/_tool"
+          test "$catalog_dir" = /opt/hostedtoolcache
+          test "$tool_cache" = "$catalog_dir"
           test -f "$tool_cache/node/24.14.1/x64.complete"
-          test -f /opt/hostedtoolcache/node/24.14.1/x64.complete
+          test "$(readlink -f "$tool_cache/node/24.14.1/x64")" = /opt/node-v24.14.1-linux-x64
+          test ! -w "$tool_cache/node/24.14.1/x64/bin/node"
           if touch /.self-hosted-runner-node-smoke; then
             rm -f /.self-hosted-runner-node-smoke
-            echo "the runner root filesystem must be read-only" >&2
-            exit 1
-          fi
-          if touch /opt/hostedtoolcache/.self-hosted-runner-node-smoke; then
-            rm -f /opt/hostedtoolcache/.self-hosted-runner-node-smoke
-            echo "the image tool cache must be read-only" >&2
+            echo "the filesystem root must not be writable by the runner" >&2
             exit 1
           fi
 

--- a/.github/workflows/super-linter.yml
+++ b/.github/workflows/super-linter.yml
@@ -23,6 +23,8 @@ jobs:
     # GITHUB_TOKEN, so passing repository secrets would over-provision it.
     uses: f5-sales-demo/docs-control/.github/workflows/super-linter.yml@b68cf1496e1a695751efee5114ddfe24f7cd9e35
     with:
+      socketless_runner_label: docs-socketless
+      container_build_runner_label: docs-container-build
       classify_xc_minimum_configs: ${{ github.repository == 'f5-sales-demo/terraform-provider-xcsh' }}
     permissions:
       contents: read # checkout repository content in the reusable workflow

--- a/.github/workflows/translation-audit.yml
+++ b/.github/workflows/translation-audit.yml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   audit:
     name: English-only documentation policy
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Record suspended translation policy
         run: |

--- a/.github/workflows/workflow-security-audit.yml
+++ b/.github/workflows/workflow-security-audit.yml
@@ -85,7 +85,7 @@ jobs:
   audit:
     name: Audit workflows (zizmor)
     if: github.event_name != 'pull_request'
-    runs-on: [self-hosted, Linux, X64, "${{ github.event.repository.name }}", ubuntu-24.04]
+    runs-on: docs-socketless
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1


### PR DESCRIPTION
## Summary

- route repository Linux workflows to repository-scoped ARC labels
- pass policy-approved socketless and container labels to Pages and Super-Linter
- align the toolchain smoke with the ARC image catalog boundary
- preserve permissions, event guards, environments, dependencies, and disabled AGY workflows

## Validation

- actionlint and yamllint across every changed workflow
- complete active/disabled workflow routing audit
- changed-scope PII enforcement

AGY is intentionally disabled and bypassed.

Closes #1332