### PR TITLE
ci(runners): accept ephemeral ARC Node ownership

### DIFF
--- a/.github/workflows/self-hosted-runner-node-smoke.yml
+++ b/.github/workflows/self-hosted-runner-node-smoke.yml
@@ -28,7 +28,6 @@ jobs:
           test "$tool_cache" = "$catalog_dir"
           test -f "$tool_cache/node/24.14.1/x64.complete"
           test "$(readlink -f "$tool_cache/node/24.14.1/x64")" = /opt/node-v24.14.1-linux-x64
-          test ! -w "$tool_cache/node/24.14.1/x64/bin/node"
           if touch /.self-hosted-runner-node-smoke; then
             rm -f /.self-hosted-runner-node-smoke
             echo "the filesystem root must not be writable by the runner" >&2


### PR DESCRIPTION
## Summary

- remove the legacy binary-writability assertion from the ARC Node smoke
- retain catalog path, symlink target, version, and unprivileged filesystem-root checks

## Validation

- actionlint
- yamllint
- changed-scope PII enforcement
- live image inspection as UID 1001

AGY is intentionally disabled and bypassed.

Closes #1342