### PR TITLE
feat!: require Node 24 and upgrade scroll-to-top

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21,7 +21,7 @@
         "starlight-openapi": "^0.26.1",
         "starlight-page-actions": "^0.7.1",
         "starlight-plugin-icons": "^1.1.6",
-        "starlight-scroll-to-top": "^1.0.1",
+        "starlight-scroll-to-top": "^2.0.0",
         "starlight-videos": "^0.5.0",
         "unist-util-visit": "^5.1.0"
       },
@@ -44,7 +44,7 @@
         "vitest": "^4.1.11"
       },
       "engines": {
-        "node": ">=22.23.2"
+        "node": ">=24.19.0"
       },
       "peerDependencies": {
         "@astrojs/markdown-remark": "^7.2.4",
@@ -6392,9 +6392,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-      "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+      "version": "3.1.7",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+      "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
       "funding": [
         {
           "type": "github",
@@ -9124,9 +9124,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.16",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
-      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
+      "version": "3.3.18",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.18.tgz",
+      "integrity": "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w==",
       "funding": [
         {
           "type": "github",
@@ -10787,15 +10787,15 @@
       }
     },
     "node_modules/starlight-scroll-to-top": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/starlight-scroll-to-top/-/starlight-scroll-to-top-1.0.1.tgz",
-      "integrity": "sha512-OkSVwEQBzHkYPgBYL/O9xSiFn75j6HvrmjvdL8+3Kk0oxgt4sNmkOwhB0bGjB/T7M7SAJ4AFk1Ojza1HVxOeHQ==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/starlight-scroll-to-top/-/starlight-scroll-to-top-2.0.0.tgz",
+      "integrity": "sha512-KXvghfBr7nGLDhmWCP5/BXQOgZ60J4NSXsqbvWryZ5hUXeonSXR0Zl45j/+bZh1L9eWf3AYTV6YZT1HXXNdSlA==",
       "license": "MIT",
       "engines": {
         "node": ">=22.12.0"
       },
       "peerDependencies": {
-        "@astrojs/starlight": ">=0.38.0"
+        "@astrojs/starlight": ">=0.41.0"
       }
     },
     "node_modules/starlight-videos": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "F5 Distributed Cloud branded Starlight documentation theme",
   "type": "module",
   "engines": {
-    "node": ">=22.23.2"
+    "node": ">=24.19.0"
   },
   "bin": {
     "docs-translate": "./bin/translate.mjs"
@@ -144,7 +144,7 @@
     "starlight-openapi": "^0.26.1",
     "starlight-page-actions": "^0.7.1",
     "starlight-plugin-icons": "^1.1.6",
-    "starlight-scroll-to-top": "^1.0.1",
+    "starlight-scroll-to-top": "^2.0.0",
     "starlight-videos": "^0.5.0",
     "unist-util-visit": "^5.1.0"
   },


### PR DESCRIPTION
## Summary

- Require Node.js 24.19 or newer, matching the managed Node 24 workflow runtime.
- Upgrade starlight-scroll-to-top to v2.
- Regenerate the lockfile and refresh vulnerable transitives.

## Validation

- Node.js 24.20.0 / npm 11.19.0
- `npm ci --ignore-scripts`
- `npm test`
- `npm run build`
- `npm audit --audit-level=high` (0 vulnerabilities)
- Headless browser UAT: scroll control is visible, has the `Scroll to top` accessible label, and returns the page to scrollY 0.
- Responsive visual assertions: 4 passed. The broader screenshot suite has no Linux baselines on main, so its 12 comparisons are not usable as regression evidence.

Closes #1425
Closes #1426
