### PR TITLE
fix(deps): adopt stable llms-txt 2.0.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@anthropic-ai/sdk": "^0.121.0",
         "@astrojs/react": "^6.0.4",
         "@f5-sales-demo/i18n-core": "^1.0.56",
-        "@f5-sales-demo/starlight-llms-txt": "2.0.0-rc.0",
+        "@f5-sales-demo/starlight-llms-txt": "2.0.0",
         "@f5-sales-demo/starlight-mega-menu": "^2.1.59",
         "gray-matter": "^4.0.3",
         "remark-code-import": "^1.2.0",
@@ -1748,9 +1748,9 @@
       }
     },
     "node_modules/@f5-sales-demo/starlight-llms-txt": {
-      "version": "2.0.0-rc.0",
-      "resolved": "https://registry.npmjs.org/@f5-sales-demo/starlight-llms-txt/-/starlight-llms-txt-2.0.0-rc.0.tgz",
-      "integrity": "sha512-ABd8WnKZhuFbzMQv+gGbhPUT1/nY8OZKCaBeqAaeb8196g6pni8FDCSvM299rIX1jIHSGkPP6wNucEWWwraO+Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/@f5-sales-demo/starlight-llms-txt/-/starlight-llms-txt-2.0.0.tgz",
+      "integrity": "sha512-20HsnWTCGbchYiTOBvbO01D5y5fzJwa3BqrRF0p/M+QouHCahmCBm0WCJ4tCPvjTCQtp9PyC7euV0NeNUMUfCA==",
       "license": "MIT",
       "dependencies": {
         "@astrojs/mdx": "^7.0.8",

--- a/package.json
+++ b/package.json
@@ -139,7 +139,7 @@
     "@anthropic-ai/sdk": "^0.121.0",
     "@astrojs/react": "^6.0.4",
     "@f5-sales-demo/i18n-core": "^1.0.56",
-    "@f5-sales-demo/starlight-llms-txt": "2.0.0-rc.0",
+    "@f5-sales-demo/starlight-llms-txt": "2.0.0",
     "@f5-sales-demo/starlight-mega-menu": "^2.1.59",
     "gray-matter": "^4.0.3",
     "remark-code-import": "^1.2.0",


### PR DESCRIPTION
## Summary
- pin `@f5-sales-demo/starlight-llms-txt` to the published stable `2.0.0` release
- refresh the lockfile to the published artifact and its verified integrity

## Verification
- `npm ci --legacy-peer-deps`
- `npm test` (50 passed)
- `npm run build` (generated `llms.txt`, `llms-full.txt`, and `llms-small.txt`)
- `npm audit --omit=dev --audit-level=high` (0 vulnerabilities)

Closes #1436